### PR TITLE
Confusion between getRestMethodName and getName ?

### DIFF
--- a/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -50,7 +50,7 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
 
         HttpResponse response = httpClient.execute(request);
 
-        return deserializeResponse(response, clientRequest.getName(), clientRequest.getPathToResult());
+        return deserializeResponse(response, clientRequest.getRestMethodName(), clientRequest.getPathToResult());
 
     }
 


### PR DESCRIPTION
Most actions define the Rest Method name (Eg : DeleteIndex) but do not override getName
However, the name is then used in AbstractJestClient.isOperationSucceed and this method expect the name of the REST operation.

So I guess the second argument in deserializeResponse should be the rest method name, no ?
