### PR TITLE
Shutdown correction + corrected 40x response code handling

### DIFF
--- a/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -84,17 +84,25 @@ public abstract class AbstractJestClient implements JestClient {
             }
         } else {
             result.setSucceeded(false);
+            // provide the generic HTTP status code error, if one hasn't already come in via the JSON response...
+            // eg.
+            //  IndicesExist will return 404 (with no content at all) for a missing index, but:
+            //  Update will return 404 (with an error message for DocumentMissingException)
+            if (result.getErrorMessage() == null) {
+                result.setErrorMessage(statusLine.getStatusCode() + " " + statusLine.getReasonPhrase());
+            }
             log.debug("Response is failed");
         }
         return result;
     }
 
     protected JsonObject convertJsonStringToMapObject(String jsonTxt) {
-      if(jsonTxt == null || jsonTxt.trim().isEmpty())return null;
-      try {
-            return new JsonParser().parse(jsonTxt).getAsJsonObject();
-        } catch (Exception e) {
-            log.error("An exception occurred while converting json string to map object");
+        if (jsonTxt != null && !jsonTxt.trim().isEmpty()) {
+            try {
+                return new JsonParser().parse(jsonTxt).getAsJsonObject();
+            } catch (Exception e) {
+                log.error("An exception occurred while converting json string to map object");
+            }
         }
         return new JsonObject();
     }

--- a/src/main/java/io/searchbox/client/JestResult.java
+++ b/src/main/java/io/searchbox/client/JestResult.java
@@ -31,6 +31,7 @@ public class JestResult {
     private String pathToResult;
 
     private boolean isSucceeded;
+    private String errorMessage;
 
     public String getPathToResult() {
         return pathToResult;
@@ -61,7 +62,7 @@ public class JestResult {
     }
 
     public String getErrorMessage() {
-        return jsonObject.get("error").getAsString();
+        return errorMessage;
     }
 
     public JsonObject getJsonObject() {
@@ -257,5 +258,13 @@ public class JestResult {
 
     public void setJsonObject(JsonObject jsonObject) {
         this.jsonObject = jsonObject;
+        if (jsonObject.get("error") != null) {
+            errorMessage = jsonObject.get("error").getAsString();
+        }
+    }
+
+    /** manually set an error message, eg. for the cases where non-200 response code is received */
+    public void setErrorMessage(String errorMessage) {
+        this.errorMessage = errorMessage;
     }
 }

--- a/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -176,7 +176,10 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
     }
 
     private JestResult deserializeResponse(HttpResponse response, Action clientRequest) throws IOException {
-        return createNewElasticSearchResult(EntityUtils.toString(response.getEntity()), response.getStatusLine(), clientRequest);
+        return createNewElasticSearchResult(
+                response.getEntity() != null ? EntityUtils.toString(response.getEntity()) : null,
+                response.getStatusLine(),
+                clientRequest);
     }
 
     public HttpClient getHttpClient() {


### PR DESCRIPTION
Two changes that I've needed for my instance:

a) code to shutdown the Async client correctly;
b) code to handle 401 (and other 40x response codes without entities) without failing, and being able to communicate the actual error response code back to the caller

Without (a), a shutdown leaves a whole lot of threads running for the async client.

Without (b), a 404 not found response (eg. from IndicesExist on a non-existent index), or a 401 response (from a custom Elastic authentication plugin) causes the JestClient to NullPointer.
