### PR TITLE
Update to elasticsearch 0.90.5 and fix test cases.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,14 +61,14 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<junit.version>4.11</junit.version>
 		<gson.version>2.2.3</gson.version>
-		<elasticsearch.version>0.90.2</elasticsearch.version>
+		<elasticsearch.version>0.90.5</elasticsearch.version>
 		<log4j.version>1.2.16</log4j.version>
 		<httpComponent.version>4.2.3</httpComponent.version>
 		<httpClient.version>4.2.3</httpClient.version>
 		<httpAsyncClient.version>4.0-beta3</httpAsyncClient.version>
 		<commonsLang.version>2.4</commonsLang.version>
 		<slf4j.version>1.7.5</slf4j.version>
-		<elasticsearch-test.version>0.0.8</elasticsearch-test.version>
+		<elasticsearch-test.version>0.90.5</elasticsearch-test.version>
 		<guava.version>14.0.1</guava.version>
 		<mockito.version>1.9.5</mockito.version>
 	</properties>

--- a/src/test/java/io/searchbox/common/CommonIntegrationTest.java
+++ b/src/test/java/io/searchbox/common/CommonIntegrationTest.java
@@ -2,6 +2,8 @@ package io.searchbox.common;
 
 import com.github.tlrx.elasticsearch.test.annotations.ElasticsearchNode;
 import com.github.tlrx.elasticsearch.test.support.junit.runners.ElasticsearchRunner;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.searchbox.AbstractAction;
 import io.searchbox.client.JestResult;
 import org.junit.Test;
@@ -36,19 +38,11 @@ public class CommonIntegrationTest extends AbstractIntegrationTest {
 
         assertNotNull(result);
 
-        String lineSeparator = System.getProperty("line.separator");
-        String expected = "{" + lineSeparator +
-                "  \"ok\" : true," + lineSeparator +
-                "  \"status\" : 200," + lineSeparator +
-                "  \"name\" : \"elasticsearch-test-node\"," + lineSeparator +
-                "  \"version\" : {" + lineSeparator +
-                "    \"number\" : \"0.90.2\"," + lineSeparator +
-                "    \"snapshot_build\" : false," + lineSeparator +
-                "    \"lucene_version\" : \"4.3.1\"" + lineSeparator +
-                "  }," + lineSeparator +
-                "  \"tagline\" : \"You Know, for Search\"" + lineSeparator +
-                "}";
+        JsonObject jsonObject = result.getJsonObject();
 
-        assertEquals(expected, result.getJsonString());
+        assertEquals("true", jsonObject.get("ok").getAsString());
+        assertEquals("200", jsonObject.get("status").getAsString());
+        JsonObject versionObj = jsonObject.get("version").getAsJsonObject();
+        assertEquals("0.90.5", versionObj.get("number").getAsString());
     }
 }

--- a/src/test/java/io/searchbox/indices/aliases/ModifyAliasesIntegrationTest.java
+++ b/src/test/java/io/searchbox/indices/aliases/ModifyAliasesIntegrationTest.java
@@ -49,7 +49,7 @@ public class ModifyAliasesIntegrationTest extends AbstractIntegrationTest {
 
         ClusterState clusterState = adminClient.cluster().state(new ClusterStateRequest()).actionGet(10, TimeUnit.SECONDS).getState();
         assertNotNull(clusterState);
-        ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
+        Map<String, Map<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
         Map<String, AliasMetaData> aliasMetaDataMap = aliases.get(alias);
         assertNotNull(aliasMetaDataMap);
         assertEquals(1, aliasMetaDataMap.size());
@@ -73,7 +73,7 @@ public class ModifyAliasesIntegrationTest extends AbstractIntegrationTest {
 
         ClusterState clusterState = adminClient.cluster().state(new ClusterStateRequest()).actionGet(10, TimeUnit.SECONDS).getState();
         assertNotNull(clusterState);
-        ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
+        Map<String, Map<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
         Map<String, AliasMetaData> aliasMetaDataMap = aliases.get(alias);
         assertNotNull(aliasMetaDataMap);
         assertEquals(2, aliasMetaDataMap.size());
@@ -99,7 +99,7 @@ public class ModifyAliasesIntegrationTest extends AbstractIntegrationTest {
 
         ClusterState clusterState = adminClient.cluster().state(new ClusterStateRequest()).actionGet(10, TimeUnit.SECONDS).getState();
         assertNotNull(clusterState);
-        ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
+        Map<String, Map<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
         Map<String, AliasMetaData> aliasMetaDataMap = aliases.get(alias);
         assertNotNull(aliasMetaDataMap);
         assertEquals(1, aliasMetaDataMap.size());
@@ -129,7 +129,7 @@ public class ModifyAliasesIntegrationTest extends AbstractIntegrationTest {
 
         ClusterState clusterState = adminClient.cluster().state(new ClusterStateRequest()).actionGet(10, TimeUnit.SECONDS).getState();
         assertNotNull(clusterState);
-        ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
+        Map<String, Map<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
         assertFalse(aliases.containsKey(alias));
     }
 
@@ -157,7 +157,7 @@ public class ModifyAliasesIntegrationTest extends AbstractIntegrationTest {
 
         ClusterState clusterState = adminClient.cluster().state(new ClusterStateRequest()).actionGet(10, TimeUnit.SECONDS).getState();
         assertNotNull(clusterState);
-        ImmutableMap<String, ImmutableMap<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
+        Map<String, Map<String, AliasMetaData>> aliases = clusterState.getMetaData().getAliases();
         Map<String, AliasMetaData> aliasMetaDataMap = aliases.get(alias);
         assertNotNull(aliasMetaDataMap);
         assertEquals(1, aliasMetaDataMap.size());


### PR DESCRIPTION
Update elasticsearch and elasticsearch-test dependencies to 0.90.5

Modified CommonIntegrationTest to not be so dependent on what the server returns.

Fixed BulkIntegrationTest so it doesn't break if timezone the code is run in is different enough from UTC to be a different day.
