### PR TITLE
Fixed NumberFormatException

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ client.execute(index);
 class Article {
 
 @JestId
-private Long documentId;
+private String documentId;
 
 }
 ```


### PR DESCRIPTION
Elasticsearch generates document id as String. If you define documentId field as Long, you will get NumberFormatException
