### PR TITLE
Upgrade to HttpClient 4.3.x.

### DIFF
--- a/jest/src/test/java/io/searchbox/client/JestClientFactoryTest.java
+++ b/jest/src/test/java/io/searchbox/client/JestClientFactoryTest.java
@@ -4,13 +4,12 @@ import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.client.http.JestHttpClient;
 import org.apache.http.HttpHost;
 import org.apache.http.conn.routing.HttpRoute;
-import org.apache.http.impl.conn.BasicClientConnectionManager;
-import org.apache.http.impl.conn.PoolingClientConnectionManager;
-import org.apache.http.params.CoreConnectionPNames;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.junit.Before;
 import org.junit.Test;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 
 /**
  * @author Dogukan Sonmez
@@ -27,24 +26,14 @@ public class JestClientFactoryTest {
     }
 
     @Test
-    public void clientCreation() {
-        JestHttpClient jestClient = (JestHttpClient) factory.getObject();
-        assertTrue(jestClient != null);
-        assertNotNull(jestClient.getAsyncClient());
-        assertTrue(jestClient.getHttpClient().getConnectionManager() instanceof BasicClientConnectionManager);
-        assertEquals(jestClient.getServers().size(), 1);
-        assertTrue(jestClient.getServers().contains("http://localhost:9200"));
-    }
-
-    @Test
     public void clientCreationWithTimeout() {
         HttpClientConfig httpClientConfig = new HttpClientConfig.Builder(
                 "someUri").connTimeout(150).readTimeout(300).build();
         factory.setHttpClientConfig(httpClientConfig);
         JestHttpClient jestClient = (JestHttpClient) factory.getObject();
-
-        assertEquals(150, jestClient.getHttpClient().getParams().getParameter(CoreConnectionPNames.CONNECTION_TIMEOUT));
-        assertEquals(300, jestClient.getHttpClient().getParams().getParameter(CoreConnectionPNames.SO_TIMEOUT));
+        assertNotNull(jestClient.getDefaultRequestConfig());
+        assertEquals(150, jestClient.getDefaultRequestConfig().getConnectionRequestTimeout());
+        assertEquals(300, jestClient.getDefaultRequestConfig().getSocketTimeout());
     }
 
     @Test
@@ -53,7 +42,7 @@ public class JestClientFactoryTest {
         JestHttpClient jestClient = (JestHttpClient) factory.getObject();
         assertTrue(jestClient != null);
         assertNotNull(jestClient.getAsyncClient());
-        assertTrue(jestClient.getHttpClient().getConnectionManager() instanceof BasicClientConnectionManager);
+        assertTrue(jestClient.getConnectionManager() instanceof BasicHttpClientConnectionManager);
         assertEquals(jestClient.getServers().size(), 1);
         assertTrue(jestClient.getServers().contains("http://localhost:9200"));
     }
@@ -85,15 +74,13 @@ public class JestClientFactoryTest {
 
         assertTrue(jestClient != null);
         assertNotNull(jestClient.getAsyncClient());
-        assertTrue(jestClient.getHttpClient().getConnectionManager() instanceof PoolingClientConnectionManager);
-        assertEquals(10, ((PoolingClientConnectionManager) jestClient.getHttpClient().getConnectionManager()).getDefaultMaxPerRoute());
-        assertEquals(20, ((PoolingClientConnectionManager) jestClient.getHttpClient().getConnectionManager()).getMaxTotal());
-        assertEquals(5, ((PoolingClientConnectionManager) jestClient.getHttpClient().getConnectionManager()).getMaxPerRoute(routeOne));
-        assertEquals(6, ((PoolingClientConnectionManager) jestClient.getHttpClient().getConnectionManager()).getMaxPerRoute(routeTwo));
+        assertTrue(jestClient.getConnectionManager() instanceof PoolingHttpClientConnectionManager);
+        assertEquals(10, ((PoolingHttpClientConnectionManager) jestClient.getConnectionManager()).getDefaultMaxPerRoute());
+        assertEquals(20, ((PoolingHttpClientConnectionManager) jestClient.getConnectionManager()).getMaxTotal());
+        assertEquals(5, ((PoolingHttpClientConnectionManager) jestClient.getConnectionManager()).getMaxPerRoute(routeOne));
+        assertEquals(6, ((PoolingHttpClientConnectionManager) jestClient.getConnectionManager()).getMaxPerRoute(routeTwo));
 
         assertEquals(jestClient.getServers().size(), 1);
         assertTrue(jestClient.getServers().contains("http://localhost:9200"));
     }
-
-
 }

--- a/pom.xml
+++ b/pom.xml
@@ -72,15 +72,15 @@
         <elasticsearch.version>0.90.5</elasticsearch.version>
         <elasticsearch-test.version>0.90.5</elasticsearch-test.version>
 
-        <httpComponent.version>4.2.3</httpComponent.version>
-        <httpClient.version>4.2.3</httpClient.version>
-        <httpAsyncClient.version>4.0-beta3</httpAsyncClient.version>
+        <httpComponent.version>4.3.1</httpComponent.version>
+        <httpClient.version>4.3.2</httpClient.version>
+        <httpAsyncClient.version>4.0</httpAsyncClient.version>
         <httpclientandroidlib.version>1.1.2</httpclientandroidlib.version>
 
         <slf4j.version>1.7.5</slf4j.version>
         <log4j.version>1.2.16</log4j.version>
 
-        <guava.version>14.0.1</guava.version>
+        <guava.version>16.0</guava.version>
         <gson.version>2.2.3</gson.version>
         <mockito.version>1.9.5</mockito.version>
 


### PR DESCRIPTION
Upgrade to HttpClient 4.3 and Guava 16.

Notes: 
- The only reason I added the _connectionManager_ and _defaultRequestConfig_ properties to `JestHttpClient` is to allow `JestClientFactoryTest` to keep doing what it has always been doing.
- Callling `JestClientFactoryTest.getObject()` without a config now uses HttpClient's default connection manager, which is the `PoolingHttpClientConnectionManager` instead of the `BasicHttpClientConnectionManager`.
