### PR TITLE
Upgrade gson to 2.2.4 due to hashing bug in 2.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <log4j.version>1.2.16</log4j.version>
 
         <guava.version>16.0</guava.version>
-        <gson.version>2.2.3</gson.version>
+        <gson.version>2.2.4</gson.version>
         <mockito.version>1.9.5</mockito.version>
 
         <commonsLang.version>3.1</commonsLang.version>


### PR DESCRIPTION
I uncovered an intermittent and very hard to detect hashing bug in gson 2.2.3.  According to gson roadmap (see here: https://sites.google.com/site/gson/gson-roadmap), this bug was fixed in 2.2.4.  I was able to confirm this in my project by excluding 2.2.3 from jest and including 2.2.4 directly into my project.  Let me know if you have any questions.
