### PR TITLE
allow iteration of hits with access to source and explanation

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -308,11 +308,11 @@ public class JestResult {
 		}
 
     	public <T> T getSource(Class<T> type) {
-    		return createSourceObject(source, type); 
+    		return source != null ? createSourceObject(source, type) : null; 
     	}
     	
     	public <T> T getExplanation(Class<T> type) {
-    		return createSourceObject(explanation, type);
+    		return explanation != null ? createSourceObject(explanation, type) : null;
     	}
     }    
 }


### PR DESCRIPTION
This is an attempt to implement issue #106 
It will allow the client to access the source and explanation without Jest needing a dependency to lucene.

```
JestResult result = client.execute(search);
List<JestSearchHit> hits = result.getHits().getHits();
for (JestSearchHit jr : hits) {
    MyType mt = jr.getSource(MyType.class);
    Explanation e = jr.getExplanation(Explanation.class);
}
```
