### PR TITLE
added JestHttpClient  logging information

### DIFF
--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -168,7 +168,7 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
             entity = gson.toJson(data);
         }
         
-        log.debug("request body to json - "+ data);
+        log.debug("request body - "+ entity);
         
         return entity;
     }


### PR DESCRIPTION
hello.
i use RoundrobinServerList by JestHttpClient.

normally, i think we need to know to below informations for the debugging. 
1. elasticSearchRestUrl and method info.
2. requestBody as json string.

specially, when you use RoundRobinServer Method.
clearly need to know that information.
because according to the roundRobin method, change host at the call each time.

so i added logging information.
how are you thinking?

would you please to accept my pull request?
thank you.
