### PR TITLE
ignore_indices parameter is ignored

### DIFF
--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
@@ -34,7 +34,7 @@ public abstract class AbstractMultiIndexActionBuilder<T extends Action, K> exten
      *                      "missing" (Indices / aliases that are missing will be excluded from a request.)
      */
     public K ignoreIndices(String ignoreIndices) {
-        setParameter(Parameters.IGNORE_INDICES, null);
+        setParameter(Parameters.IGNORE_INDICES, ignoreIndices);
         return (K) this;
     }
 


### PR DESCRIPTION
Results in an NPE if you attempt to use the ignoreIndices setting when searching.
