### PR TITLE
Issue #130 - Changed default GSON date format to match elasticsearch

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -2,6 +2,7 @@ package io.searchbox.client;
 
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import io.searchbox.client.config.RoundRobinServerList;
 import io.searchbox.client.config.ServerList;
 import io.searchbox.client.config.discovery.NodeChecker;
@@ -19,8 +20,11 @@ import java.util.Set;
 public abstract class AbstractJestClient implements JestClient {
 
     final static Logger log = LoggerFactory.getLogger(AbstractJestClient.class);
+    public static final String ELASTIC_SEARCH_DATE_FORMAT = "yyyy-MM-dd'T'hh:mm:ssZ";
     private final PaddedAtomicReference<ServerList> listOfServers = new PaddedAtomicReference<ServerList>();
-    protected Gson gson = new Gson();
+    protected Gson gson = new GsonBuilder()
+            .setDateFormat(ELASTIC_SEARCH_DATE_FORMAT)
+            .create();
     private NodeChecker nodeChecker;
 
     public void setNodeChecker(NodeChecker nodeChecker) {

--- a/jest/src/test/java/io/searchbox/core/IndexIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/IndexIntegrationTest.java
@@ -4,10 +4,12 @@ import io.searchbox.action.Action;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.indices.mapping.PutMapping;
 import org.elasticsearch.test.ElasticsearchIntegrationTest;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
@@ -18,26 +20,29 @@ import java.util.concurrent.ExecutionException;
 @ElasticsearchIntegrationTest.ClusterScope(scope = ElasticsearchIntegrationTest.Scope.SUITE, numNodes = 1)
 public class IndexIntegrationTest extends AbstractIntegrationTest {
 
+    public static final String INDEX_NAME = "twitter";
+    public static final String TYPE_NAME = "tweet";
+
     Map<Object, Object> source = new HashMap<Object, Object>();
 
     @Test
     public void indexDocumentWithValidParametersAndWithoutSettings() throws IOException {
         source.put("user", "searchbox");
-        JestResult result = client.execute(new Index.Builder(source).index("twitter").type("tweet").id("1").build());
+        JestResult result = client.execute(new Index.Builder(source).index(INDEX_NAME).type(TYPE_NAME).id("1").build());
         executeTestCase(result);
     }
 
     @Test
     public void automaticIdGeneration() throws IOException {
         source.put("user", "jest");
-        JestResult result = client.execute(new Index.Builder(source).index("twitter").type("tweet").build());
+        JestResult result = client.execute(new Index.Builder(source).index(INDEX_NAME).type(TYPE_NAME).build());
         executeTestCase(result);
     }
 
     @Test
     public void indexAsynchronously() throws InterruptedException, ExecutionException, IOException {
         source.put("user", "jest");
-        Action action = new Index.Builder(source).index("twitter").type("tweet").build();
+        Action action = new Index.Builder(source).index(INDEX_NAME).type(TYPE_NAME).build();
 
         client.executeAsync(action, new JestResultHandler<JestResult>() {
             @Override
@@ -60,8 +65,27 @@ public class IndexIntegrationTest extends AbstractIntegrationTest {
         }
     }
 
+    @Test
+    public void shouldIndexDateFieldsWithoutFormatConversion() throws Exception {
+        putMappingAndCheckSuccess();
+        source.put("user", "searchbox");
+        source.put("creationDate", new Date());
+        JestResult result = client.execute(new Index.Builder(source).index(INDEX_NAME).type(TYPE_NAME).id("1").build());
+        executeTestCase(result);
+    }
+
+    private void putMappingAndCheckSuccess() throws IOException {
+        createIndex(INDEX_NAME);
+        PutMapping putMapping = new PutMapping.Builder(INDEX_NAME, TYPE_NAME,
+                "{ \"" + TYPE_NAME + "\" : { \"properties\" : { \"creationDate\" : {\"type\" : \"date\"} } } }"
+        ).build();
+        JestResult result = client.execute(putMapping);
+        assertNotNull("Can't put mapping", result);
+        assertTrue(result.isSucceeded());
+    }
+
     private void executeTestCase(JestResult result) {
         assertNotNull(result);
-        assertTrue(result.isSucceeded());
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
     }
 }


### PR DESCRIPTION
 `{"type": "date"}` defaults.

Failing test case `IndexIntegrationTest#shouldIndexDateFieldsWithoutFormatConversion`\+ fix `AbstractJestClient#gson`
