### PR TITLE
Discovered NPE when discovery is enabled and nodes do not have http_address element

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -49,8 +49,11 @@ public class NodeChecker extends AbstractScheduledService {
             if (nodes != null) {
                 for (Entry<String, JsonElement> entry : nodes.entrySet()) {
                     JsonObject host = (JsonObject) entry.getValue();
-                    String http_address = host.get("http_address").getAsString();
-                    if (null != http_address) {
+
+                    // get as a JsonElement first as some nodes in the cluster may not have an http_address
+                    JsonElement addressElement = host.get("http_address");
+                    if (null != addressElement) {
+                        String http_address = addressElement.getAsString();
                         String cleanHttpAddress = "http://" + http_address.substring(6, http_address.length() - 1);
                         httpHosts.add(cleanHttpAddress);
                     }


### PR DESCRIPTION
Some cluster nodes (i.e. logstash nodes or I imagine any with http.enabled set to false) will not have the http_address element as part of their result.  To avoid a NPE, need to check that the element exists before trying to get it as a string.
