### PR TITLE
Adding the simplest Suggest Action

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Suggest.java
+++ b/jest-common/src/main/java/io/searchbox/core/Suggest.java
@@ -1,0 +1,69 @@
+package io.searchbox.core;
+
+import io.searchbox.action.AbstractAction;
+import io.searchbox.action.AbstractMultiTypeActionBuilder;
+import io.searchbox.client.JestResult;
+
+import com.google.gson.Gson;
+
+public class Suggest extends AbstractAction<JestResult> {
+
+    private final String query;
+
+    private Suggest(final Builder builder) {
+        super(builder);
+
+        this.query = builder.getQuery();
+        this.setURI(this.buildURI());
+    }
+
+    @Override
+    public JestResult createNewElasticSearchResult(final String json, final int statusCode, final String reasonPhrase, final Gson gson) {
+        return this.createNewElasticSearchResult(new JestResult(gson), json, statusCode, reasonPhrase, gson);
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "POST";
+    }
+
+    public String getIndex() {
+        return this.indexName;
+    }
+
+    public String getType() {
+        return this.typeName;
+    }
+
+    @Override
+    public Object getData(final Gson gson) {
+        return this.query;
+    }
+
+    @Override
+    protected String buildURI() {
+        final StringBuilder sb = new StringBuilder();
+        sb.append(super.buildURI()).append("/_suggest");
+        return sb.toString();
+    }
+
+    public static class Builder extends AbstractMultiTypeActionBuilder<Suggest, Builder> {
+
+        private final String query;
+
+        public Builder(final String query) {
+            this.query = query;
+        }
+
+        public final String getQuery() {
+            return this.query;
+        }
+
+        @Override
+        public Suggest build() {
+            return new Suggest(this);
+        }
+
+    }
+
+}

--- a/jest-common/src/test/java/io/searchbox/core/SuggestTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SuggestTest.java
@@ -1,0 +1,67 @@
+package io.searchbox.core;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import io.searchbox.action.Action;
+import io.searchbox.client.JestResult;
+
+import org.junit.Test;
+
+public class SuggestTest {
+
+    @Test
+    public void getURIWithoutIndexAndType() {
+        Action<JestResult> suggest = new Suggest.Builder("").build();
+        assertEquals("_all/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithOnlyOneIndex() {
+        Action<JestResult> suggest = new Suggest.Builder("").addIndex("twitter").build();
+        assertEquals("twitter/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithOneIndexAndOneType() {
+        Action<JestResult> suggest = new Suggest.Builder("").addIndex("twitter").addType("tweet").build();
+        assertEquals("twitter/tweet/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithOnlyOneType() {
+        Action<JestResult> suggest = new Suggest.Builder("").addType("tweet").build();
+        assertEquals("_all/tweet/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithOnlyMultipleIndex() {
+        Action<JestResult> suggest = new Suggest.Builder("").addIndex("twitter").addIndex("suggestbox").build();
+        assertEquals("twitter%2Csuggestbox/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithOnlyMultipleType() {
+        Action<JestResult> suggest = new Suggest.Builder("").addType("tweet").addType("jest").build();
+        assertEquals("_all/tweet%2Cjest/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getURIWithMultipleIndexAndTypes() {
+        Action<JestResult> suggest = new Suggest.Builder("")
+            .addIndex("twitter")
+            .addIndex("suggestbox")
+            .addType("tweet")
+            .addType("jest")
+            .build();
+        assertEquals("twitter%2Csuggestbox/tweet%2Cjest/_suggest", suggest.getURI());
+    }
+
+    @Test
+    public void getDataSimple() {
+        String query = "{\"elementSuggestion\":{\"text\":\"courgette\",\"completion\":{\"field\":\"element.completion\",\"size\":10,\"fuzzy\":{}}}}";
+        Action<JestResult> suggest = new Suggest.Builder(query).build();
+
+        assertNotNull("data", suggest.getData(null));
+        assertEquals(query, suggest.getData(null).toString());
+    }
+}


### PR DESCRIPTION
Adding the simplest Suggest Action.
Link with :
- [Implement suggest api](https://github.com/searchbox-io/Jest/issues/30)
- [completion suggester](https://github.com/searchbox-io/Jest/pull/94)