### PR TITLE
replace ignore_indices to corresponding parameters supported in 1.x

### DIFF
--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
@@ -25,16 +25,20 @@ public abstract class AbstractMultiIndexActionBuilder<T extends Action, K> exten
     }
 
     /**
-     * All multi indices API support the ignore_indices option.
-     * Setting it to missing will cause indices that do not exists
-     * to be ignored from the execution. By default, when its not
-     * set, the request will fail.
-     *
-     * @param ignoreIndices "none" (No indices / aliases will be excluded from a request) or
-     *                      "missing" (Indices / aliases that are missing will be excluded from a request.)
+     * Ignore unavailable indices, this includes indices that not exists or closed indices.
+     * @param ignore whether to ignore unavailable indices
      */
-    public K ignoreIndices(String ignoreIndices) {
-        setParameter(Parameters.IGNORE_INDICES, ignoreIndices);
+    public K ignoreUnavailable(boolean ignore) {
+        setParameter(Parameters.IGNORE_UNAVAILABLE, String.valueOf(ignore));
+        return (K) this;
+    }
+
+    /**
+     * Fail of wildcard indices expressions results into no concrete indices.
+     * @param allow whether to allow no indices.
+     */
+    public K allowNoIndices(boolean allow) {
+        setParameter(Parameters.ALLOW_NO_INDICES, String.valueOf(allow));
         return (K) this;
     }
 

--- a/jest-common/src/main/java/io/searchbox/params/Parameters.java
+++ b/jest-common/src/main/java/io/searchbox/params/Parameters.java
@@ -18,8 +18,11 @@ public class Parameters {
     // 'camelCase'
     public static final String RESULT_CASING = "case";
 
-    // 'none' | 'missing'
-    public static final String IGNORE_INDICES = "ignore_indices";
+    // 'true' | 'false'
+    public static final String IGNORE_UNAVAILABLE = "ignore_unavailable";
+
+    // 'true' | 'false'
+    public static final String ALLOW_NO_INDICES = "allow_no_indices";
 
     //'quorum' | 'one' | 'all'
     public static final String CONSISTENCY = "consistency";


### PR DESCRIPTION
`ignore_indices` parameter for multi-index search is not supported in ES 1.x, it is replaced by `ignore_unavailable` and `allow_no_indices` - http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.x/multi-index.html.
