### PR TITLE
gson document field exclusion strategy  logic added

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -3,12 +3,15 @@ package io.searchbox.client;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import io.searchbox.client.config.RoundRobinServerList;
 import io.searchbox.client.config.ServerList;
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.exception.NoServerConfiguredException;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
 import io.searchbox.client.util.PaddedAtomicReference;
+import io.searchbox.core.gson.DocumentExclusionStrategy;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,6 +27,7 @@ public abstract class AbstractJestClient implements JestClient {
     public static final String ELASTIC_SEARCH_DATE_FORMAT = "yyyy-MM-dd'T'HH:mm:ssZ";
     private final PaddedAtomicReference<ServerList> listOfServers = new PaddedAtomicReference<ServerList>();
     protected Gson gson = new GsonBuilder()
+            .setExclusionStrategies(DocumentExclusionStrategy.create())
             .setDateFormat(ELASTIC_SEARCH_DATE_FORMAT)
             .create();
 

--- a/jest-common/src/main/java/io/searchbox/core/gson/DocumentExclusionStrategy.java
+++ b/jest-common/src/main/java/io/searchbox/core/gson/DocumentExclusionStrategy.java
@@ -1,0 +1,39 @@
+package io.searchbox.core.gson;
+
+import com.google.gson.ExclusionStrategy;
+import com.google.gson.FieldAttributes;
+
+/**
+ * @author happyprg
+ */
+
+public class DocumentExclusionStrategy implements ExclusionStrategy {
+
+	private final Class<?> typeToSkip;
+
+	private DocumentExclusionStrategy() {
+		this.typeToSkip = null;
+	}
+
+	private DocumentExclusionStrategy(Class<?> typeToSkip) {
+		this.typeToSkip = typeToSkip;
+	}
+
+	@Override
+	public boolean shouldSkipClass(Class<?> clazz) {
+		return (clazz == typeToSkip);
+	}
+
+	@Override
+	public boolean shouldSkipField(FieldAttributes f) {
+		return f.getAnnotation(Exclude.class) != null;
+	}
+
+	public static DocumentExclusionStrategy createWithSkipType(Class<?> typeToSkip) {
+		return new DocumentExclusionStrategy(typeToSkip);
+	}
+
+	public static DocumentExclusionStrategy create() {
+		return new DocumentExclusionStrategy();
+	}
+}

--- a/jest-common/src/main/java/io/searchbox/core/gson/Exclude.java
+++ b/jest-common/src/main/java/io/searchbox/core/gson/Exclude.java
@@ -1,0 +1,16 @@
+package io.searchbox.core.gson;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author happyprg
+ */
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD})
+public @interface Exclude {
+
+}

--- a/jest-common/src/test/java/io/searchbox/core/gson/DocumentExclusionStrategyTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/gson/DocumentExclusionStrategyTest.java
@@ -1,0 +1,53 @@
+package io.searchbox.core.gson;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
+/**
+ * @author happyprg
+ */
+
+public class DocumentExclusionStrategyTest {
+
+	public final SampleObjectForTest original = new SampleObjectForTest(5, "iloveLeeSeoHoo", 1234);
+
+	@Test
+	public void exclude() {
+
+		Gson exclusionStrategyAwareGson = new GsonBuilder().setExclusionStrategies(DocumentExclusionStrategy.create())
+															.create();
+
+		String expected = exclusionStrategyAwareGson.toJson(original);
+		String actual = "{\"stringField\":\"iloveLeeSeoHoo\",\"longField\":1234}"; //ignored annotatedField
+		assertEquals(expected, actual);
+	}
+
+	@Test
+	public void excludeWithType() {
+
+		Gson exclusionStrategyAwareGson = new GsonBuilder().setExclusionStrategies(DocumentExclusionStrategy.createWithSkipType(String.class))
+															.create();
+
+		String expected = exclusionStrategyAwareGson.toJson(original);
+		String actual = "{\"longField\":1234}"; //ignored annotatedField, skipType
+		assertEquals(expected, actual);
+	}
+
+	public static class SampleObjectForTest {
+
+		@Exclude
+		private final int annotatedField;
+		private final String stringField;
+		private final long longField;
+
+		public SampleObjectForTest(int annotatedField, String stringField, long longField) {
+			this.annotatedField = annotatedField;
+			this.stringField = stringField;
+			this.longField = longField;
+		}
+	}
+}


### PR DESCRIPTION
hello friends.

when i want ignore fields of document.

the default Gson instance of AbstractJestClient Class has no function.

so i added the Gson document field exclusion strategy logic.
following the guide line.
https://sites.google.com/site/gson/gson-user-guide#TOC-User-Defined-Exclusion-Strategies

it would be default guideline in JestClient when serialization  the document for indexing
please look at my pull request.