### PR TITLE
Added aggregation support (#146)

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Thanks to [JetBrains][jetbrains] for providing a license for [IntelliJ IDEA][ide
 We also would like to thank the following people for their significant contributions.
 * [Andrea Turli](https://github.com/andreaturli)
 * [asierdelpozo](https://github.com/asierdelpozo)
+* [Clayton Stout](https://github.com/cfstout)
 * [Dominic Tootell](https://github.com/tootedom)
 * [Erik Schuchmann](https://github.com/eschuchmann)
 * [Filippo Rossoni](https://github.com/filippor)

--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -178,18 +178,12 @@ public class SearchResult extends JestResult {
     }
 
     public Aggregation getAggregations() {
-        if (jsonObject != null) {
-            JsonObject aggregationsMap;
-            if (jsonObject.has("aggregations")) {
-                aggregationsMap = (JsonObject) jsonObject.get("aggregations");
-            } else if (jsonObject.has("aggs")) {
-                aggregationsMap = (JsonObject) jsonObject.get("aggs");
-            } else {
-                return new Aggregation("aggs", new JsonObject());
-            }
-            return new Aggregation("aggs", aggregationsMap);
-        }
-        return new Aggregation("aggs", new JsonObject());
+        final String rootAggrgationName = "aggs";
+        if (jsonObject == null) return new Aggregation(rootAggrgationName, new JsonObject());
+        if (jsonObject.has("aggregations")) return new Aggregation(rootAggrgationName, jsonObject.getAsJsonObject("aggregations"));
+        if (jsonObject.has("aggs")) return new Aggregation(rootAggrgationName, jsonObject.getAsJsonObject("aggs"));
+
+        return new Aggregation(rootAggrgationName, new JsonObject());
     }
 
     /**

--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -4,6 +4,7 @@ import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.searchbox.client.JestResult;
+import io.searchbox.core.search.aggregation.Aggregation;
 import io.searchbox.core.search.facet.Facet;
 
 import java.lang.reflect.Constructor;
@@ -174,6 +175,21 @@ public class SearchResult extends JestResult {
             }
         }
         return facets;
+    }
+
+    public Aggregation getAggregations() {
+        if (jsonObject != null) {
+            JsonObject aggregationsMap;
+            if (jsonObject.has("aggregations")) {
+                aggregationsMap = (JsonObject) jsonObject.get("aggregations");
+            } else if (jsonObject.has("aggs")) {
+                aggregationsMap = (JsonObject) jsonObject.get("aggs");
+            } else {
+                return new Aggregation("aggs", new JsonObject());
+            }
+            return new Aggregation("aggs", aggregationsMap);
+        }
+        return new Aggregation("aggs", new JsonObject());
     }
 
     /**

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Aggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Aggregation.java
@@ -1,0 +1,261 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import java.lang.reflect.Constructor;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+
+public class Aggregation <T extends Aggregation>  {
+
+    protected String name;
+    protected JsonObject jsonRoot;
+
+    public Aggregation(String name, JsonObject jsonRoot) {
+        this.name = name;
+        this.jsonRoot = jsonRoot;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * @param nameToTypeMap a map of aggNames to their expected type (extension of Aggregation class)
+     * @return A list of aggregation objects for the provided name:type pairs if the name can be found in the root json object
+     * @exception java.lang.RuntimeException if no constructor found for an expected type in the map
+     */
+    public List<T> getAggregations(Map<String, Class<T>> nameToTypeMap) {
+        List<T> aggregations = new ArrayList<T>();
+        for (String nameCandidate : nameToTypeMap.keySet()) {
+            if (jsonRoot.has(nameCandidate)) {
+                try {
+                    Class<T> type = nameToTypeMap.get(nameCandidate);
+                    Constructor<T> c = type.getConstructor(String.class, JsonObject.class);
+                    aggregations.add(c.newInstance(nameCandidate, jsonRoot.getAsJsonObject(nameCandidate)));
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+        return aggregations;
+    }
+
+    /**
+     * @param aggName Name of the desired aggregation
+     * @param aggType Extension of Aggregation class expected as return type
+     * @return Aggregation of type T if aggName can be found in aggregation json or null otherwise
+     * @exception java.lang.RuntimeException if no constructor exists for provided aggType
+     */
+    public T getAggregation(String aggName, Class<T> aggType) {
+        if(jsonRoot.has(aggName)) {
+            try {
+                Constructor<T> c = aggType.getConstructor(String.class, JsonObject.class);
+                return c.newInstance(aggName, jsonRoot.getAsJsonObject(aggName));
+            } catch(Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * @param aggName Name of the AvgAggregation
+     * @return a new AvgAggregation object if aggName is found in root json object or null if not found
+     */
+    public AvgAggregation getAvgAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new AvgAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the CardinalityAggregation
+     * @return a new CardinalityAggregation object if aggName is found in root json object or null if not found
+     */
+    public CardinalityAggregation getCardinalityAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new CardinalityAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the DateHistogramAggregation
+     * @return a new DateHistogramAggregation object if aggName is found in root json object or null if not found
+     */
+    public DateHistogramAggregation getDateHistogramAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new DateHistogramAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the DateRangeAggregation
+     * @return a new DateRangeAggregation object if aggName is found in root json object or null if not found
+     */
+    public DateRangeAggregation getDateRangeAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new DateRangeAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the ExtendedStatsAggregation
+     * @return a new ExtendedStatsAggregation object if aggName is found in root json object or null if not found
+     */
+    public ExtendedStatsAggregation getExtendedStatsAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new ExtendedStatsAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the FilterAggregation
+     * @return a new FilterAggregation object if aggName is found in root json object or null if not found
+     */
+    public FilterAggregation getFilterAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new FilterAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the FiltersAggregation
+     * @return a new FiltersAggregation object if aggName is found in root json object or null if not found
+     */
+    public FiltersAggregation getFiltersAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new FiltersAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the GeoBoundsAggregation
+     * @return a new GeoBoundsAggregation object if aggName is found in root json object or null if not found
+     */
+    public GeoBoundsAggregation getGeoBoundsAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new GeoBoundsAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the GeoDistanceAggregation
+     * @return a new GeoDistanceAggregation object if aggName is found in root json object or null if not found
+     */
+    public GeoDistanceAggregation getGeoDistanceAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new GeoDistanceAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the GeohashGridAggregation
+     * @return a new GeohashGridAggregation object if aggName is found in root json object or null if not found
+     */
+    public GeohashGridAggregation getGeohashGridAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new GeohashGridAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the HistogramAggregation
+     * @return a new HistogramAggregation object if aggName is found in root json object or null if not found
+     */
+    public HistogramAggregation getHistogramAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new HistogramAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the Ipv4RangeAggregation
+     * @return a new Ipv4RangeAggregation object if aggName is found in root json object or null if not found
+     */
+    public Ipv4RangeAggregation getIpv4RangeAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new Ipv4RangeAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the MaxAggregation
+     * @return a new MaxAggregation object if aggName is found in root json object or null if not found
+     */
+    public MaxAggregation getMaxAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new MaxAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the MinAggregation
+     * @return a new MinAggregation object if aggName is found in root json object or null if not found
+     */
+    public MinAggregation getMinAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new MinAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the MissingAggregation
+     * @return a new MissingAggregation object if aggName is found in root json object or null if not found
+     */
+    public MissingAggregation getMissingAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new MissingAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the PercentileRanksAggregation
+     * @return a new PercentileRanksAggregation object if aggName is found in root json object or null if not found
+     */
+    public PercentileRanksAggregation getPercentileRanksAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new PercentileRanksAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the PercentilesAggregation
+     * @return a new PercentilesAggregation object if aggName is found in root json object or null if not found
+     */
+    public PercentilesAggregation getPercentilesAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new PercentilesAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the RangeAggregation
+     * @return a new RangeAggregation object if aggName is found in root json object or null if not found
+     */
+    public RangeAggregation getRangeAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new RangeAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the ScriptedMetricAggregation
+     * @return a new ScriptedMetricAggregation object if aggName is found in root json object or null if not found
+     */
+    public ScriptedMetricAggregation getScriptedMetricAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new ScriptedMetricAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the SignificantTermsAggregation
+     * @return a new SignificantTermsAggregation object if aggName is found in root json object or null if not found
+     */
+    public SignificantTermsAggregation getSignificantTermsAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new SignificantTermsAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the StatsAggregation
+     * @return a new StatsAggregation object if aggName is found in root json object or null if not found
+     */
+    public StatsAggregation getStatsAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new StatsAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the SumAggregation
+     * @return a new SumAggregation object if aggName is found in root json object or null if not found
+     */
+    public SumAggregation getSumAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new SumAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the TermsAggregation
+     * @return a new TermsAggregation object if aggName is found in root json object or null if not found
+     */
+    public TermsAggregation getTermsAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new TermsAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+    /**
+     * @param aggName Name of the ValueCountAggregation
+     * @return a new ValueCountAggregation object if aggName is found in root json object or null if not found
+     */
+    public ValueCountAggregation getValueCountAggregation(String aggName) {
+        return jsonRoot.has(aggName) ? new ValueCountAggregation(aggName, jsonRoot.getAsJsonObject(aggName)) : null;
+    }
+
+
+
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/AggregationField.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/AggregationField.java
@@ -1,0 +1,53 @@
+package io.searchbox.core.search.aggregation;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+public enum AggregationField {
+    VALUE("value"),
+    BUCKETS("buckets"),
+    KEY("key"), //Can be String or Long
+    KEY_AS_STRING("key_as_string"),
+    DOC_COUNT("doc_count"),
+    FROM("from"),
+    TO("to"),
+    FROM_AS_STRING("from_as_string"),
+    TO_AS_STRING("to_as_string"),
+    SUM_OF_SQUARES("sum_of_squares"),
+    VARIANCE("variance"),
+    STD_DEVIATION("std_deviation"),
+    BOUNDS("bounds"),
+    TOP_LEFT("top_left"),
+    BOTTOM_RIGHT("bottom_right"),
+    LAT("lat"),
+    LON("lon"),
+    UNIT("unit"),
+    VALUES("values"),
+    SCORE("score"),
+    BG_COUNT("bg_count"), //Background Count
+    COUNT("count"),
+    MIN("min"),
+    MAX("max"),
+    AVG("avg"),
+    SUM("sum"),
+    DOC_COUNT_ERROR_UPPER_BOUND("doc_count_error_upper_bound"),
+    SUM_OTHER_DOC_COUNT("sum_other_doc_count");
+
+    private final String field;
+
+    private AggregationField(String s) {
+        field = s;
+    }
+
+    public String toString() {
+        return field;
+    }
+
+    public boolean equals(String s) {
+        return s.equals(toString());
+    }
+}
+

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/AvgAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/AvgAggregation.java
@@ -1,0 +1,35 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class AvgAggregation extends SingleValueAggregation<AvgAggregation> {
+
+    public static final String TYPE = "avg";
+
+    public <T extends Aggregation> AvgAggregation(String name, JsonObject avgAggregation) {
+        super(name, avgAggregation);
+    }
+
+    /**
+     * @return Average if it was found and not null, null otherwise
+     */
+    public Double getAvg() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AvgAggregation)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
@@ -1,0 +1,51 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class CardinalityAggregation extends Aggregation<CardinalityAggregation> {
+
+    public static final String TYPE = "cardinality";
+
+    private Long cardinality;
+
+    public <T extends Aggregation> CardinalityAggregation(String name, JsonObject cardinalityAggregation) {
+        super(name, cardinalityAggregation);
+        cardinality = cardinalityAggregation.get(String.valueOf(VALUE)).getAsLong();
+    }
+
+    /**
+     * @return Cardinality if it was found and not null, null otherwise
+     */
+    public Long getCardinality() {
+        return cardinality;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof CardinalityAggregation)) {
+            return false;
+        }
+
+        CardinalityAggregation that = (CardinalityAggregation) o;
+
+        if (cardinality != null ? !cardinality.equals(that.cardinality) : that.cardinality != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return cardinality != null ? cardinality.hashCode() : 0;
+    }
+}
+

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -34,18 +36,17 @@ public class CardinalityAggregation extends Aggregation<CardinalityAggregation> 
             return false;
         }
 
-        CardinalityAggregation that = (CardinalityAggregation) o;
-
-        if (cardinality != null ? !cardinality.equals(that.cardinality) : that.cardinality != null) {
-            return false;
-        }
-
-        return true;
+        CardinalityAggregation rhs = (CardinalityAggregation) o;
+        return new EqualsBuilder()
+                .append(getCardinality(), rhs.getCardinality())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return cardinality != null ? cardinality.hashCode() : 0;
+        return new HashCodeBuilder()
+                .append(getCardinality())
+                .toHashCode();
     }
 }
 

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -67,19 +69,24 @@ public class DateHistogramAggregation extends Aggregation<DateHistogramAggregati
             if (!(o instanceof DateHistogram)) {
                 return false;
             }
-
-            DateHistogram that = (DateHistogram) o;
-
-            if (!timeAsString.equals(that.timeAsString)) {
+            if (!super.equals(o)) {
                 return false;
             }
 
-            return true;
+            DateHistogram rhs = (DateHistogram) o;
+            return new EqualsBuilder()
+                    .append(getTimeAsString(), rhs.getTimeAsString())
+                    .append(getTime(), rhs.getTime())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            return timeAsString.hashCode();
+            return new HashCodeBuilder()
+                    .appendSuper(super.hashCode())
+                    .append(getTimeAsString())
+                    .append(getTime())
+                    .toHashCode();
         }
     }
 
@@ -92,17 +99,16 @@ public class DateHistogramAggregation extends Aggregation<DateHistogramAggregati
             return false;
         }
 
-        DateHistogramAggregation that = (DateHistogramAggregation) o;
-
-        if (!dateHistograms.equals(that.dateHistograms)) {
-            return false;
-        }
-
-        return true;
+        DateHistogramAggregation rhs = (DateHistogramAggregation) o;
+        return new EqualsBuilder()
+                .append(getDateHistograms(), rhs.getDateHistograms())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return dateHistograms.hashCode();
+        return new HashCodeBuilder()
+                .append(getDateHistograms())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
@@ -1,0 +1,108 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY_AS_STRING;
+
+/**
+ * @author cfstout
+ */
+public class DateHistogramAggregation extends Aggregation<DateHistogramAggregation> {
+
+    public static final String TYPE = "date_histogram";
+
+    private List<DateHistogram> dateHistograms;
+
+    public DateHistogramAggregation(String name, JsonObject dateHistogramAggregation) {
+        super(name, dateHistogramAggregation);
+        dateHistograms = new ArrayList<DateHistogram>();
+        if (!dateHistogramAggregation.has(String.valueOf(BUCKETS)) || dateHistogramAggregation.get(String.valueOf(BUCKETS)).isJsonNull()) {
+            return;
+        }
+        for (JsonElement bucket : dateHistogramAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonElement time = bucket.getAsJsonObject().get(String.valueOf(KEY));
+            JsonElement timeAsString = bucket.getAsJsonObject().get(String.valueOf(KEY_AS_STRING));
+            JsonElement count = bucket.getAsJsonObject().get(String.valueOf(DOC_COUNT));
+            DateHistogram histogram = new DateHistogram(time.getAsLong(), timeAsString.getAsString(), count.getAsLong());
+            dateHistograms.add(histogram);
+        }
+    }
+
+    /**
+     * @return List of DateHistogram objects if found, or empty list otherwise
+     */
+    public List<DateHistogram> getDateHistograms() {
+        return dateHistograms;
+    }
+
+    public class DateHistogram extends HistogramAggregation.Histogram {
+
+        private String timeAsString;
+
+        DateHistogram(Long time, String timeAsString, Long count) {
+            super(time, count);
+            this.timeAsString = timeAsString;
+        }
+
+        public Long getTime() {
+            return getKey();
+        }
+
+        public String getTimeAsString() {
+            return timeAsString;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DateHistogram)) {
+                return false;
+            }
+
+            DateHistogram that = (DateHistogram) o;
+
+            if (!timeAsString.equals(that.timeAsString)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            return timeAsString.hashCode();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DateHistogramAggregation)) {
+            return false;
+        }
+
+        DateHistogramAggregation that = (DateHistogramAggregation) o;
+
+        if (!dateHistograms.equals(that.dateHistograms)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return dateHistograms.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
@@ -1,0 +1,92 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.FROM;
+import static io.searchbox.core.search.aggregation.AggregationField.FROM_AS_STRING;
+import static io.searchbox.core.search.aggregation.AggregationField.TO;
+import static io.searchbox.core.search.aggregation.AggregationField.TO_AS_STRING;
+
+/**
+ * @author cfstout
+ */
+public class DateRangeAggregation extends Aggregation<DateRangeAggregation> {
+
+    public static final String TYPE = "date_range";
+
+    private List<DateRange> ranges;
+
+    public <T extends Aggregation> DateRangeAggregation(String name, JsonObject dateRangeAggregation) {
+        super(name, dateRangeAggregation);
+        ranges = new ArrayList<DateRange>();
+        //todo support keyed:true as well
+        for (JsonElement bucketv : dateRangeAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            DateRange range = new DateRange(
+                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsDouble() : null,
+                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsDouble() : null,
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong(),
+                    bucket.has(String.valueOf(FROM_AS_STRING)) ? bucket.get(String.valueOf(FROM_AS_STRING)).getAsString() : null,
+                    bucket.has(String.valueOf(TO_AS_STRING)) ? bucket.get(String.valueOf(TO_AS_STRING)).getAsString() : null);
+            ranges.add(range);
+        }
+    }
+
+    public List<DateRange> getRanges() {
+        return ranges;
+    }
+
+    public class DateRange extends RangeAggregation.Range {
+        private String fromAsString;
+        private String toAsString;
+
+        public DateRange(Double from, Double to, Long count, String fromString, String toString){
+            super(from, to, count);
+            this.fromAsString = fromString;
+            this.toAsString = toString;
+        }
+
+        /**
+         * @return From time as a string, or null if not specified
+         */
+        public String getFromAsString() {
+            return fromAsString;
+        }
+
+        /**
+         * @return To time as a string, or null if not specified
+         */
+        public String getToAsString() {
+            return toAsString;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof DateRangeAggregation)) {
+            return false;
+        }
+
+        DateRangeAggregation that = (DateRangeAggregation) o;
+
+        if (!ranges.equals(that.ranges)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return ranges.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -46,7 +48,7 @@ public class DateRangeAggregation extends Aggregation<DateRangeAggregation> {
         private String fromAsString;
         private String toAsString;
 
-        public DateRange(Double from, Double to, Long count, String fromString, String toString){
+        public DateRange(Double from, Double to, Long count, String fromString, String toString) {
             super(from, to, count);
             this.fromAsString = fromString;
             this.toAsString = toString;
@@ -65,6 +67,34 @@ public class DateRangeAggregation extends Aggregation<DateRangeAggregation> {
         public String getToAsString() {
             return toAsString;
         }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof DateRange)) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            DateRange rhs = (DateRange) o;
+            return new EqualsBuilder()
+                    .append(getFromAsString(), rhs.getFromAsString())
+                    .append(getToAsString(), rhs.getToAsString())
+                    .isEquals();
+        }
+
+        @Override
+        public int hashCode() {
+            return new HashCodeBuilder()
+                    .appendSuper(super.hashCode())
+                    .append(getFromAsString())
+                    .append(getToAsString())
+                    .toHashCode();
+        }
     }
 
     @Override
@@ -76,17 +106,16 @@ public class DateRangeAggregation extends Aggregation<DateRangeAggregation> {
             return false;
         }
 
-        DateRangeAggregation that = (DateRangeAggregation) o;
-
-        if (!ranges.equals(that.ranges)) {
-            return false;
-        }
-
-        return true;
+        DateRangeAggregation rhs = (DateRangeAggregation) o;
+        return new EqualsBuilder()
+                .append(getRanges(), rhs.getRanges())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return ranges.hashCode();
+        return new HashCodeBuilder()
+                .append(getRanges())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.STD_DEVIATION;
 import static io.searchbox.core.search.aggregation.AggregationField.SUM_OF_SQUARES;
@@ -58,27 +60,21 @@ public class ExtendedStatsAggregation extends StatsAggregation<ExtendedStatsAggr
             return false;
         }
 
-        ExtendedStatsAggregation that = (ExtendedStatsAggregation) o;
-
-        if (stdDeviation != null ? !stdDeviation.equals(that.stdDeviation) : that.stdDeviation != null) {
-            return false;
-        }
-        if (sumOfSquares != null ? !sumOfSquares.equals(that.sumOfSquares) : that.sumOfSquares != null) {
-            return false;
-        }
-        if (variance != null ? !variance.equals(that.variance) : that.variance != null) {
-            return false;
-        }
-
-        return super.equals(o);
+        ExtendedStatsAggregation rhs = (ExtendedStatsAggregation) o;
+        return new EqualsBuilder()
+                .append(getStdDeviation(), rhs.getStdDeviation())
+                .append(getSumOfSquares(), rhs.getSumOfSquares())
+                .append(getVariance(), rhs.getVariance())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = super.hashCode();
-        result = 31 * result + (sumOfSquares != null ? sumOfSquares.hashCode() : 0);
-        result = 31 * result + (variance != null ? variance.hashCode() : 0);
-        result = 31 * result + (stdDeviation != null ? stdDeviation.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .appendSuper(super.hashCode())
+                .append(getSumOfSquares())
+                .append(getVariance())
+                .append(getStdDeviation())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
@@ -1,0 +1,84 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.STD_DEVIATION;
+import static io.searchbox.core.search.aggregation.AggregationField.SUM_OF_SQUARES;
+import static io.searchbox.core.search.aggregation.AggregationField.VARIANCE;
+
+/**
+ * @author cfstout
+ */
+public class ExtendedStatsAggregation extends StatsAggregation<ExtendedStatsAggregation> {
+
+    private Double sumOfSquares;
+    private Double variance;
+    private Double stdDeviation;
+
+    public <T extends Aggregation> ExtendedStatsAggregation(String name, JsonObject extendedStatsAggregation) {
+        super(name, extendedStatsAggregation);
+        this.sumOfSquares = !extendedStatsAggregation.has(String.valueOf(SUM_OF_SQUARES)) || extendedStatsAggregation.get(String.valueOf(SUM_OF_SQUARES)).isJsonNull() ?
+                null : extendedStatsAggregation.get(String.valueOf(SUM_OF_SQUARES)).getAsDouble();
+        this.variance = !extendedStatsAggregation.has(String.valueOf(VARIANCE)) || extendedStatsAggregation.get(String.valueOf(VARIANCE)).isJsonNull() ?
+                null : extendedStatsAggregation.get(String.valueOf(VARIANCE)).getAsDouble();
+        this.stdDeviation = !extendedStatsAggregation.has(String.valueOf(STD_DEVIATION)) || extendedStatsAggregation.get(String.valueOf(STD_DEVIATION)).isJsonNull() ?
+                null : extendedStatsAggregation.get(String.valueOf(STD_DEVIATION)).getAsDouble();
+    }
+
+    /**
+     * @return Sum of Squares for the aggregated data if found, null otherwise
+     */
+    public Double getSumOfSquares() {
+        return sumOfSquares;
+    }
+
+    /**
+     * @return Variance of the aggregated data if found, null otherwise
+     */
+    public Double getVariance() {
+        return variance;
+    }
+
+    /**
+     * @return Standard deviation of the aggregated data if found, null otherwise
+     */
+    public Double getStdDeviation() {
+        return stdDeviation;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+
+        ExtendedStatsAggregation that = (ExtendedStatsAggregation) o;
+
+        if (stdDeviation != null ? !stdDeviation.equals(that.stdDeviation) : that.stdDeviation != null) {
+            return false;
+        }
+        if (sumOfSquares != null ? !sumOfSquares.equals(that.sumOfSquares) : that.sumOfSquares != null) {
+            return false;
+        }
+        if (variance != null ? !variance.equals(that.variance) : that.variance != null) {
+            return false;
+        }
+
+        return super.equals(o);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = super.hashCode();
+        result = 31 * result + (sumOfSquares != null ? sumOfSquares.hashCode() : 0);
+        result = 31 * result + (variance != null ? variance.hashCode() : 0);
+        result = 31 * result + (stdDeviation != null ? stdDeviation.hashCode() : 0);
+        return result;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
@@ -1,0 +1,47 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+
+/**
+ * @author cfstout
+ */
+public class FilterAggregation extends Aggregation<FilterAggregation> {
+
+    public static final String TYPE = "filter";
+
+    private Long count;
+
+    public <T extends Aggregation> FilterAggregation(String name, JsonObject filterAggregation) {
+        super(name, filterAggregation);
+        this.count = filterAggregation.get(String.valueOf(DOC_COUNT)).getAsLong();
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FilterAggregation)) {
+            return false;
+        }
+
+        FilterAggregation that = (FilterAggregation) o;
+
+        if (!count.equals(that.count)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return count.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
 
@@ -31,17 +33,16 @@ public class FilterAggregation extends Aggregation<FilterAggregation> {
             return false;
         }
 
-        FilterAggregation that = (FilterAggregation) o;
-
-        if (!count.equals(that.count)) {
-            return false;
-        }
-
-        return true;
+        FilterAggregation rhs = (FilterAggregation) o;
+        return new EqualsBuilder()
+                .append(getCount(), rhs.getCount())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return count.hashCode();
+        return new HashCodeBuilder()
+                .append(getCount())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
@@ -3,6 +3,8 @@ package io.searchbox.core.search.aggregation;
 import com.google.common.collect.Lists;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -67,23 +69,19 @@ public class FiltersAggregation extends Aggregation<FiltersAggregation> {
             return false;
         }
 
-        FiltersAggregation that = (FiltersAggregation) o;
-
-        if (!countList.equals(that.countList)) {
-            return false;
-        }
-        if (!counts.equals(that.counts)) {
-            return false;
-        }
-
-        return true;
+        FiltersAggregation rhs = (FiltersAggregation) o;
+        return new EqualsBuilder()
+                .append(getCountList(), rhs.getCountList())
+                .append(getCounts(), rhs.getCounts())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = counts.hashCode();
-        result = 31 * result + countList.hashCode();
-        return result;
+        return new HashCodeBuilder()
+                .append(getCountList())
+                .append(getCounts())
+                .toHashCode();
     }
 }
 

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
@@ -1,0 +1,89 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.common.collect.Lists;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+
+/**
+ * @author cfstout
+ */
+public class FiltersAggregation extends Aggregation<FiltersAggregation> {
+
+    public static final String TYPE = "filters";
+
+    private Map<String, Long> counts;
+    private List<Long> countList;
+
+    public <T extends Aggregation> FiltersAggregation(String name, JsonObject filtersAggregation) {
+        super(name, filtersAggregation);
+        counts = new HashMap<String, Long>();
+        countList = new ArrayList<Long>();
+        if (filtersAggregation.get(String.valueOf(BUCKETS)).isJsonArray()) {
+            int elementNumber = 0;
+            for (JsonElement bucket : filtersAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+                Long count = bucket.getAsJsonObject().get(String.valueOf(DOC_COUNT)).getAsLong();
+                counts.put("filter" + Integer.toString(elementNumber++), count);
+                countList.add(count);
+            }
+        } else { // returned as a json object
+            for (Map.Entry<String, JsonElement> bucket: filtersAggregation.get(String.valueOf(BUCKETS)).getAsJsonObject().entrySet()) {
+                Long count = bucket.getValue().getAsJsonObject().get(String.valueOf(DOC_COUNT)).getAsLong();
+                counts.put(bucket.getKey(), count);
+                countList.add(count);
+            }
+        }
+    }
+
+    /**
+     * Method for getting counts when filters when using anonymous filtering
+     * @return A list of counts in the order that the filters were passed in
+     */
+    public List<Long> getCountList() {
+        return countList;
+    }
+
+    /**
+     * Method for getting counts using named filters
+     * @return A map filter names to associated counts
+     */
+    public Map<String, Long> getCounts() {
+        return counts;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof FiltersAggregation)) {
+            return false;
+        }
+
+        FiltersAggregation that = (FiltersAggregation) o;
+
+        if (!countList.equals(that.countList)) {
+            return false;
+        }
+        if (!counts.equals(that.counts)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = counts.hashCode();
+        result = 31 * result + countList.hashCode();
+        return result;
+    }
+}
+

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.BOTTOM_RIGHT;
 import static io.searchbox.core.search.aggregation.AggregationField.BOUNDS;
@@ -71,30 +73,22 @@ public class GeoBoundsAggregation extends Aggregation<GeoBoundsAggregation> {
             return false;
         }
 
-        GeoBoundsAggregation that = (GeoBoundsAggregation) o;
-
-        if (bottomRightLat != null ? !bottomRightLat.equals(that.bottomRightLat) : that.bottomRightLat != null) {
-            return false;
-        }
-        if (bottomRightLon != null ? !bottomRightLon.equals(that.bottomRightLon) : that.bottomRightLon != null) {
-            return false;
-        }
-        if (topLeftLat != null ? !topLeftLat.equals(that.topLeftLat) : that.topLeftLat != null) {
-            return false;
-        }
-        if (topLeftLon != null ? !topLeftLon.equals(that.topLeftLon) : that.topLeftLon != null) {
-            return false;
-        }
-
-        return true;
+        GeoBoundsAggregation rhs = (GeoBoundsAggregation) o;
+        return new EqualsBuilder()
+                .append(getBottomRightLat(), rhs.getBottomRightLat())
+                .append(getBottomRightLon(), rhs.getBottomRightLon())
+                .append(getTopLeftLat(), rhs.getTopLeftLat())
+                .append(getTopLeftLon(), rhs.getTopLeftLon())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = topLeftLat != null ? topLeftLat.hashCode() : 0;
-        result = 31 * result + (topLeftLon != null ? topLeftLon.hashCode() : 0);
-        result = 31 * result + (bottomRightLat != null ? bottomRightLat.hashCode() : 0);
-        result = 31 * result + (bottomRightLon != null ? bottomRightLon.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .append(getBottomRightLat())
+                .append(getBottomRightLon())
+                .append(getTopLeftLat())
+                .append(getTopLeftLon())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
@@ -1,0 +1,100 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BOTTOM_RIGHT;
+import static io.searchbox.core.search.aggregation.AggregationField.BOUNDS;
+import static io.searchbox.core.search.aggregation.AggregationField.LAT;
+import static io.searchbox.core.search.aggregation.AggregationField.LON;
+import static io.searchbox.core.search.aggregation.AggregationField.TOP_LEFT;
+
+/**
+ * @author cfstout
+ */
+public class GeoBoundsAggregation extends Aggregation<GeoBoundsAggregation> {
+
+    public static final String TYPE = "geo_bounds";
+
+    private Double topLeftLat;
+    private Double topLeftLon;
+    private Double bottomRightLat;
+    private Double bottomRightLon;
+
+    public GeoBoundsAggregation(String name, JsonObject geoBoundsAggregation) {
+        super(name, geoBoundsAggregation);
+        if( geoBoundsAggregation.has(String.valueOf(BOUNDS))) {
+            JsonObject bounds = geoBoundsAggregation.getAsJsonObject(String.valueOf(BOUNDS));
+            JsonObject topLeft = bounds.getAsJsonObject(String.valueOf(TOP_LEFT));
+            JsonObject bottomRight = bounds.getAsJsonObject(String.valueOf(BOTTOM_RIGHT));
+
+            topLeftLat = topLeft.get(String.valueOf(LAT)).getAsDouble();
+            topLeftLon = topLeft.get(String.valueOf(LON)).getAsDouble();
+            bottomRightLat = bottomRight.get(String.valueOf(LAT)).getAsDouble();
+            bottomRightLon = bottomRight.get(String.valueOf(LON)).getAsDouble();
+        }
+    }
+
+    /**
+     * @return Top left latitude if bounds exist, null otherwise
+     */
+    public Double getTopLeftLat() {
+        return topLeftLat;
+    }
+
+    /**
+     * @return Top left longitude if bounds exist, null otherwise
+     */
+    public Double getTopLeftLon() {
+        return topLeftLon;
+    }
+
+    /**
+     * @return Bottom right latitude if bounds exist, null otherwise
+     */
+    public Double getBottomRightLat() {
+        return bottomRightLat;
+    }
+
+    /**
+     * @return Bottom right longitude if bounds exist, null otherwise
+     */
+    public Double getBottomRightLon() {
+        return bottomRightLon;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GeoBoundsAggregation that = (GeoBoundsAggregation) o;
+
+        if (bottomRightLat != null ? !bottomRightLat.equals(that.bottomRightLat) : that.bottomRightLat != null) {
+            return false;
+        }
+        if (bottomRightLon != null ? !bottomRightLon.equals(that.bottomRightLon) : that.bottomRightLon != null) {
+            return false;
+        }
+        if (topLeftLat != null ? !topLeftLat.equals(that.topLeftLat) : that.topLeftLat != null) {
+            return false;
+        }
+        if (topLeftLon != null ? !topLeftLon.equals(that.topLeftLon) : that.topLeftLon != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = topLeftLat != null ? topLeftLat.hashCode() : 0;
+        result = 31 * result + (topLeftLon != null ? topLeftLon.hashCode() : 0);
+        result = 31 * result + (bottomRightLat != null ? bottomRightLat.hashCode() : 0);
+        result = 31 * result + (bottomRightLon != null ? bottomRightLon.hashCode() : 0);
+        return result;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
@@ -1,0 +1,67 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.*;
+
+/**
+ * @author cfstout
+ */
+public class GeoDistanceAggregation extends Aggregation<GeoDistanceAggregation> {
+
+    public static final String TYPE = "geo_distance";
+
+    private List<GeoDistance> geoDistances;
+
+    public GeoDistanceAggregation(String name, JsonObject geoDistanceAggregation) {
+        super(name, geoDistanceAggregation);
+        geoDistances = new ArrayList<GeoDistance>();
+        //todo support keyed:true as well
+        for (JsonElement bucketv : geoDistanceAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            GeoDistance geoDistance = new GeoDistance(
+                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsDouble() : null,
+                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsDouble() : null,
+                    bucket.has(String.valueOf(DOC_COUNT)) ? bucket.get(String.valueOf(DOC_COUNT)).getAsLong() : null);
+            geoDistances.add(geoDistance);
+        }
+    }
+
+    public List<GeoDistance> getGeoDistances() {
+        return geoDistances;
+    }
+
+    public class GeoDistance extends RangeAggregation.Range {
+
+        public GeoDistance(Double from, Double to, Long count) {
+            super(from, to, count);
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GeoDistanceAggregation that = (GeoDistanceAggregation) o;
+
+        if (!geoDistances.equals(that.geoDistances)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return geoDistances.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -40,6 +42,17 @@ public class GeoDistanceAggregation extends Aggregation<GeoDistanceAggregation> 
         public GeoDistance(Double from, Double to, Long count) {
             super(from, to, count);
         }
+
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GeoDistance)) {
+                return false;
+            }
+
+            return super.equals(o);
+        }
     }
 
     @Override
@@ -51,17 +64,16 @@ public class GeoDistanceAggregation extends Aggregation<GeoDistanceAggregation> 
             return false;
         }
 
-        GeoDistanceAggregation that = (GeoDistanceAggregation) o;
-
-        if (!geoDistances.equals(that.geoDistances)) {
-            return false;
-        }
-
-        return true;
+        GeoDistanceAggregation rhs = (GeoDistanceAggregation) o;
+        return new EqualsBuilder()
+                .append(getGeoDistances(), rhs.getGeoDistances())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return geoDistances.hashCode();
+        return new HashCodeBuilder()
+                .append(getGeoDistances())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeohashGridAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeohashGridAggregation.java
@@ -1,0 +1,106 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY;
+
+/**
+ * @author cfstout
+ */
+public class GeohashGridAggregation extends Aggregation<GeoBoundsAggregation> {
+
+    public static final String TYPE = "geohash_grid";
+
+    private List<GeohashGrid> geohashGrids;
+
+    public <T extends Aggregation> GeohashGridAggregation(String name, JsonObject geohashGridAggregation) {
+        super(name, geohashGridAggregation);
+        geohashGrids = new ArrayList<GeohashGrid>();
+        for (JsonElement bucketv : geohashGridAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            GeohashGrid geohashGrid = new GeohashGrid(
+                    bucket.get(String.valueOf(KEY)).getAsString(),
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong());
+            geohashGrids.add(geohashGrid);
+        }
+    }
+
+    public List<GeohashGrid> getGeohashGrids() {
+        return geohashGrids;
+    }
+
+    public static class GeohashGrid {
+        private String key;
+        private Long count;
+
+        public GeohashGrid(String key, Long count) {
+            this.key = key;
+            this.count = count;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public Long getCount() {
+            return count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof GeohashGrid)) {
+                return false;
+            }
+
+            GeohashGrid that = (GeohashGrid) o;
+
+            if (!count.equals(that.count)) {
+                return false;
+            }
+            if (!key.equals(that.key)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key.hashCode();
+            result = 31 * result + count.hashCode();
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        GeohashGridAggregation that = (GeohashGridAggregation) o;
+
+        if (geohashGrids != null ? !geohashGrids.equals(that.geohashGrids) : that.geohashGrids != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return geohashGrids != null ? geohashGrids.hashCode() : 0;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeohashGridAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeohashGridAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -61,23 +63,19 @@ public class GeohashGridAggregation extends Aggregation<GeoBoundsAggregation> {
                 return false;
             }
 
-            GeohashGrid that = (GeohashGrid) o;
-
-            if (!count.equals(that.count)) {
-                return false;
-            }
-            if (!key.equals(that.key)) {
-                return false;
-            }
-
-            return true;
+            GeohashGrid rhs = (GeohashGrid) o;
+            return new EqualsBuilder()
+                    .append(getCount(), rhs.getCount())
+                    .append(getKey(), rhs.getKey())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = key.hashCode();
-            result = 31 * result + count.hashCode();
-            return result;
+            return new HashCodeBuilder()
+                    .append(getKey())
+                    .append(getCount())
+                    .toHashCode();
         }
     }
 
@@ -90,17 +88,16 @@ public class GeohashGridAggregation extends Aggregation<GeoBoundsAggregation> {
             return false;
         }
 
-        GeohashGridAggregation that = (GeohashGridAggregation) o;
-
-        if (geohashGrids != null ? !geohashGrids.equals(that.geohashGrids) : that.geohashGrids != null) {
-            return false;
-        }
-
-        return true;
+        GeohashGridAggregation rhs = (GeohashGridAggregation) o;
+        return new EqualsBuilder()
+                .append(getGeohashGrids(), rhs.getGeohashGrids())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return geohashGrids != null ? geohashGrids.hashCode() : 0;
+        return new HashCodeBuilder()
+                .append(getGeohashGrids())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -63,23 +65,19 @@ public class HistogramAggregation extends Aggregation<HistogramAggregation> {
                 return false;
             }
 
-            Histogram histogram = (Histogram) o;
-
-            if (!count.equals(histogram.count)) {
-                return false;
-            }
-            if (!key.equals(histogram.key)) {
-                return false;
-            }
-
-            return true;
+            Histogram rhs = (Histogram) o;
+            return new EqualsBuilder()
+                    .append(getCount(), rhs.getCount())
+                    .append(getKey(), rhs.getKey())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = key.hashCode();
-            result = 31 * result + count.hashCode();
-            return result;
+            return new HashCodeBuilder()
+                    .append(getKey())
+                    .append(getCount())
+                    .toHashCode();
         }
     }
 
@@ -92,17 +90,16 @@ public class HistogramAggregation extends Aggregation<HistogramAggregation> {
             return false;
         }
 
-        HistogramAggregation that = (HistogramAggregation) o;
-
-        if (!histograms.equals(that.histograms)) {
-            return false;
-        }
-
-        return true;
+        HistogramAggregation rhs = (HistogramAggregation) o;
+        return new EqualsBuilder()
+                .append(getHistograms(), rhs.getHistograms())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return histograms.hashCode();
+        return new HashCodeBuilder()
+                .append(getHistograms())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
@@ -1,0 +1,108 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY;
+
+/**
+ * @author cfstout
+ */
+public class HistogramAggregation extends Aggregation<HistogramAggregation> {
+
+    public static final String TYPE = "histogram";
+
+    private List<Histogram> histograms;
+
+    public HistogramAggregation(String name, JsonObject histogramAggregation) {
+        super(name, histogramAggregation);
+        histograms = new ArrayList<Histogram>();
+
+        for (JsonElement bucketv : histogramAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            Histogram histogram = new Histogram(
+                    bucket.get(String.valueOf(KEY)).getAsLong(),
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong());
+            histograms.add(histogram);
+        }
+    }
+
+    public List<Histogram> getHistograms() {
+        return histograms;
+    }
+
+    public static class Histogram {
+
+        private Long key;
+        private Long count;
+
+        Histogram(Long key, Long count) {
+            this.key = key;
+            this.count = count;
+        }
+
+        public Long getKey() {
+            return key;
+        }
+
+        public Long getCount() {
+            return count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof Histogram)) {
+                return false;
+            }
+
+            Histogram histogram = (Histogram) o;
+
+            if (!count.equals(histogram.count)) {
+                return false;
+            }
+            if (!key.equals(histogram.key)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key.hashCode();
+            result = 31 * result + count.hashCode();
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        HistogramAggregation that = (HistogramAggregation) o;
+
+        if (!histograms.equals(that.histograms)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return histograms.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
@@ -1,0 +1,119 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.FROM;
+import static io.searchbox.core.search.aggregation.AggregationField.FROM_AS_STRING;
+import static io.searchbox.core.search.aggregation.AggregationField.TO;
+import static io.searchbox.core.search.aggregation.AggregationField.TO_AS_STRING;
+
+/**
+ * @author cfstout
+ */
+public class Ipv4RangeAggregation extends Aggregation<Ipv4RangeAggregation> {
+
+    public static final String TYPE = "ip_range";
+
+    private List<Ipv4Range> ranges;
+
+    public Ipv4RangeAggregation(String name, JsonObject ipv4RangeAggregation) {
+        super(name, ipv4RangeAggregation);
+        ranges = new ArrayList<Ipv4Range>();
+        //todo support keyed:true as well
+        for (JsonElement bucketv : ipv4RangeAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            Ipv4Range range = new Ipv4Range(
+                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsDouble() : null,
+                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsDouble() : null,
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong(),
+                    bucket.has(String.valueOf(FROM_AS_STRING)) ? bucket.get(String.valueOf(FROM_AS_STRING)).getAsString() : null,
+                    bucket.has(String.valueOf(TO_AS_STRING)) ? bucket.get(String.valueOf(TO_AS_STRING)).getAsString() : null);
+            ranges.add(range);
+        }
+    }
+
+    public List<Ipv4Range> getRanges() {
+        return ranges;
+    }
+
+    public class Ipv4Range extends RangeAggregation.Range {
+        private String fromAsString;
+        private String toAsString;
+
+        public Ipv4Range(Double from, Double to, Long count, String fromString, String toString){
+            super(from, to, count);
+            this.fromAsString = fromString;
+            this.toAsString = toString;
+        }
+
+        public String getFromAsString() {
+            return fromAsString;
+        }
+
+        public String getToAsString() {
+            return toAsString;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            if (!super.equals(o)) {
+                return false;
+            }
+
+            Ipv4Range ipv4Range = (Ipv4Range) o;
+
+            if (fromAsString != null ? !fromAsString.equals(ipv4Range.fromAsString) : ipv4Range.fromAsString != null) {
+                return false;
+            }
+            if (toAsString != null ? !toAsString.equals(ipv4Range.toAsString) : ipv4Range.toAsString != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = super.hashCode();
+            result = 31 * result + (fromAsString != null ? fromAsString.hashCode() : 0);
+            result = 31 * result + (toAsString != null ? toAsString.hashCode() : 0);
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        Ipv4RangeAggregation that = (Ipv4RangeAggregation) o;
+
+        if (!ranges.equals(that.ranges)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return ranges.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -26,7 +28,6 @@ public class Ipv4RangeAggregation extends Aggregation<Ipv4RangeAggregation> {
     public Ipv4RangeAggregation(String name, JsonObject ipv4RangeAggregation) {
         super(name, ipv4RangeAggregation);
         ranges = new ArrayList<Ipv4Range>();
-        //todo support keyed:true as well
         for (JsonElement bucketv : ipv4RangeAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
             JsonObject bucket = bucketv.getAsJsonObject();
             Ipv4Range range = new Ipv4Range(
@@ -73,24 +74,20 @@ public class Ipv4RangeAggregation extends Aggregation<Ipv4RangeAggregation> {
                 return false;
             }
 
-            Ipv4Range ipv4Range = (Ipv4Range) o;
-
-            if (fromAsString != null ? !fromAsString.equals(ipv4Range.fromAsString) : ipv4Range.fromAsString != null) {
-                return false;
-            }
-            if (toAsString != null ? !toAsString.equals(ipv4Range.toAsString) : ipv4Range.toAsString != null) {
-                return false;
-            }
-
-            return true;
+            Ipv4Range rhs = (Ipv4Range) o;
+            return new EqualsBuilder()
+                    .append(getToAsString(), rhs.getToAsString())
+                    .append(getFromAsString(), rhs.getFromAsString())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = super.hashCode();
-            result = 31 * result + (fromAsString != null ? fromAsString.hashCode() : 0);
-            result = 31 * result + (toAsString != null ? toAsString.hashCode() : 0);
-            return result;
+            return new HashCodeBuilder()
+                    .appendSuper(super.hashCode())
+                    .append(getToAsString())
+                    .append(getFromAsString())
+                    .toHashCode();
         }
     }
 
@@ -103,17 +100,16 @@ public class Ipv4RangeAggregation extends Aggregation<Ipv4RangeAggregation> {
             return false;
         }
 
-        Ipv4RangeAggregation that = (Ipv4RangeAggregation) o;
-
-        if (!ranges.equals(that.ranges)) {
-            return false;
-        }
-
-        return true;
+        Ipv4RangeAggregation rhs = (Ipv4RangeAggregation) o;
+        return new EqualsBuilder()
+                .append(getRanges(), rhs.getRanges())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return ranges.hashCode();
+        return new HashCodeBuilder()
+                .append(getRanges())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MaxAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MaxAggregation.java
@@ -1,0 +1,35 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+public class MaxAggregation extends SingleValueAggregation<MaxAggregation> {
+
+    public static final String TYPE = "max";
+
+    public MaxAggregation(String name, JsonObject maxAggregation) {
+        super(name, maxAggregation);
+    }
+
+    /**
+     * @return Max if it was found and not null, null otherwise
+     */
+    public Double getMax() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MaxAggregation)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MinAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MinAggregation.java
@@ -1,0 +1,35 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class MinAggregation extends SingleValueAggregation<MinAggregation> {
+
+    public static final String TYPE = "min";
+
+    public MinAggregation(String name, JsonObject minAggregation) {
+        super(name, minAggregation);
+    }
+
+    /**
+     * @return Min if it was found and not null, null otherwise
+     */
+    public Double getMin() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof MinAggregation)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
@@ -1,0 +1,47 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+
+/**
+ * @author cfstout
+ */
+
+public class MissingAggregation extends Aggregation<MissingAggregation> {
+    public static final String TYPE = "missing";
+
+    private Long missing;
+
+    public MissingAggregation(String name, JsonObject missingAggregation) {
+        super(name, missingAggregation);
+        missing = missingAggregation.get(String.valueOf(DOC_COUNT)).getAsLong();
+    }
+
+    public Long getMissing() {
+        return missing;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        MissingAggregation that = (MissingAggregation) o;
+
+        if (missing != null ? !missing.equals(that.missing) : that.missing != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return missing != null ? missing.hashCode() : 0;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
 
@@ -31,17 +33,16 @@ public class MissingAggregation extends Aggregation<MissingAggregation> {
             return false;
         }
 
-        MissingAggregation that = (MissingAggregation) o;
-
-        if (missing != null ? !missing.equals(that.missing) : that.missing != null) {
-            return false;
-        }
-
-        return true;
+        MissingAggregation rhs = (MissingAggregation) o;
+        return new EqualsBuilder()
+                .append(getMissing(), rhs.getMissing())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return missing != null ? missing.hashCode() : 0;
+        return new HashCodeBuilder()
+                .append(getMissing())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
@@ -1,0 +1,57 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUES;
+
+/**
+ * @author cfstout
+ */
+public class PercentileRanksAggregation extends Aggregation<PercentileRanksAggregation> {
+
+    public static final String TYPE = "percentile_ranks";
+
+    private Map<String, Double> percentileRanks;
+
+    public PercentileRanksAggregation(String name, JsonObject percentilesAggregation) {
+        super(name, percentilesAggregation);
+        percentileRanks = new HashMap<String, Double>();
+        JsonObject values = percentilesAggregation.getAsJsonObject(String.valueOf(VALUES));
+        for (Map.Entry<String, JsonElement> entry : values.entrySet()) {
+            if (!(Double.isNaN(entry.getValue().getAsDouble()))) {
+                percentileRanks.put(entry.getKey(), entry.getValue().getAsDouble());
+            }
+        }
+    }
+
+    public Map<String, Double> getPercentileRanks() {
+        return percentileRanks;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PercentileRanksAggregation that = (PercentileRanksAggregation) o;
+
+        if (!percentileRanks.equals(that.percentileRanks)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return percentileRanks.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -41,17 +43,16 @@ public class PercentileRanksAggregation extends Aggregation<PercentileRanksAggre
             return false;
         }
 
-        PercentileRanksAggregation that = (PercentileRanksAggregation) o;
-
-        if (!percentileRanks.equals(that.percentileRanks)) {
-            return false;
-        }
-
-        return true;
+        PercentileRanksAggregation rhs = (PercentileRanksAggregation) o;
+        return new EqualsBuilder()
+                .append(getPercentileRanks(), rhs.getPercentileRanks())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return percentileRanks.hashCode();
+        return new HashCodeBuilder()
+                .append(getPercentileRanks())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
@@ -1,0 +1,55 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+public class PercentilesAggregation extends Aggregation<PercentilesAggregation> {
+
+    public static final String TYPE = "percentiles";
+
+    private Map<String, Double> percentiles;
+
+    public PercentilesAggregation(String name, JsonObject percentilesAggregation) {
+        super(name, percentilesAggregation);
+        percentiles = new HashMap<String, Double>();
+        JsonObject values = percentilesAggregation.getAsJsonObject(String.valueOf(AggregationField.VALUES));
+        for (Map.Entry<String, JsonElement> entry : values.entrySet()) {
+            if(!(Double.isNaN(entry.getValue().getAsDouble()))) {
+                percentiles.put(entry.getKey(), entry.getValue().getAsDouble());
+            }
+        }
+    }
+
+    public Map<String, Double> getPercentiles() {
+        return percentiles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        PercentilesAggregation that = (PercentilesAggregation) o;
+
+        if (!percentiles.equals(that.percentiles)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return percentiles.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -39,17 +41,16 @@ public class PercentilesAggregation extends Aggregation<PercentilesAggregation> 
             return false;
         }
 
-        PercentilesAggregation that = (PercentilesAggregation) o;
-
-        if (!percentiles.equals(that.percentiles)) {
-            return false;
-        }
-
-        return true;
+        PercentilesAggregation rhs = (PercentilesAggregation) o;
+        return new EqualsBuilder()
+                .append(getPercentiles(), rhs.getPercentiles())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return percentiles.hashCode();
+        return new HashCodeBuilder()
+                .append(getPercentiles())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -70,27 +72,21 @@ public class RangeAggregation extends Aggregation<RangeAggregation> {
                 return false;
             }
 
-            Range range = (Range) o;
-
-            if (!count.equals(range.count)) {
-                return false;
-            }
-            if (from != null ? !from.equals(range.from) : range.from != null) {
-                return false;
-            }
-            if (to != null ? !to.equals(range.to) : range.to != null) {
-                return false;
-            }
-
-            return true;
+            Range rhs = (Range) o;
+            return new EqualsBuilder()
+                    .append(getCount(), rhs.getCount())
+                    .append(getFrom(), rhs.getFrom())
+                    .append(getTo(), rhs.getTo())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = from != null ? from.hashCode() : 0;
-            result = 31 * result + (to != null ? to.hashCode() : 0);
-            result = 31 * result + count.hashCode();
-            return result;
+            return new HashCodeBuilder()
+                    .append(getCount())
+                    .append(getFrom())
+                    .append(getTo())
+                    .toHashCode();
         }
     }
 
@@ -103,17 +99,16 @@ public class RangeAggregation extends Aggregation<RangeAggregation> {
             return false;
         }
 
-        RangeAggregation that = (RangeAggregation) o;
-
-        if (!ranges.equals(that.ranges)) {
-            return false;
-        }
-
-        return true;
+        RangeAggregation rhs = (RangeAggregation) o;
+        return new EqualsBuilder()
+                .append(getRanges(), rhs.getRanges())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return ranges.hashCode();
+        return new HashCodeBuilder()
+                .append(getRanges())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
@@ -1,0 +1,119 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.FROM;
+import static io.searchbox.core.search.aggregation.AggregationField.TO;
+
+/**
+ * @author cfstout
+ */
+public class RangeAggregation extends Aggregation<RangeAggregation> {
+
+    public static final String TYPE = "range";
+
+    private List<Range> ranges;
+
+    public RangeAggregation(String name, JsonObject rangeAggregation) {
+        super(name, rangeAggregation);
+        ranges = new ArrayList<Range>();
+        //todo support keyed:true as well
+        for (JsonElement bucketv : rangeAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            Range range = new Range(
+                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsDouble() : null,
+                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsDouble() : null,
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong());
+            ranges.add(range);
+        }
+    }
+
+    public List<Range> getRanges() {
+        return ranges;
+    }
+
+    public static class Range {
+        private Double from = Double.NEGATIVE_INFINITY;
+        private Double to = Double.POSITIVE_INFINITY;
+        private Long count;
+
+        public Range(Double from, Double to, Long count) {
+            this.count = count;
+            this.from = from;
+            this.to = to;
+        }
+
+        public Double getFrom() {
+            return from;
+        }
+
+        public Double getTo() {
+            return to;
+        }
+
+        public Long getCount() {
+            return count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Range range = (Range) o;
+
+            if (!count.equals(range.count)) {
+                return false;
+            }
+            if (from != null ? !from.equals(range.from) : range.from != null) {
+                return false;
+            }
+            if (to != null ? !to.equals(range.to) : range.to != null) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = from != null ? from.hashCode() : 0;
+            result = 31 * result + (to != null ? to.hashCode() : 0);
+            result = 31 * result + count.hashCode();
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        RangeAggregation that = (RangeAggregation) o;
+
+        if (!ranges.equals(that.ranges)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return ranges.hashCode();
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregation.java
@@ -1,0 +1,32 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class ScriptedMetricAggregation extends SingleValueAggregation<ScriptedMetricAggregation> {
+
+    public static final String TYPE = "scripted_metric";
+
+    public ScriptedMetricAggregation(String name, JsonObject scriptedMetricAggregation) {
+        super(name, scriptedMetricAggregation);
+    }
+
+    public Double getScriptedMetric() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ScriptedMetricAggregation)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
@@ -1,0 +1,145 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BG_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY;
+import static io.searchbox.core.search.aggregation.AggregationField.SCORE;
+
+/**
+ * @author cfstout
+ */
+public class SignificantTermsAggregation extends Aggregation<SignificantTermsAggregation> {
+
+    public static final String TYPE = "significant_terms";
+
+    private Long totalCount;
+    private List<SignificantTerm> significantTerms;
+
+    public SignificantTermsAggregation(String name, JsonObject significantTermsAggregation) {
+        super(name, significantTermsAggregation);
+        significantTerms = new ArrayList<SignificantTerm>();
+        for (JsonElement bucketv : significantTermsAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = bucketv.getAsJsonObject();
+            SignificantTerm term = new SignificantTerm(
+                    bucket.get(String.valueOf(KEY)).getAsString(),
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong(),
+                    bucket.get(String.valueOf(SCORE)).getAsDouble(),
+                    bucket.get(String.valueOf(BG_COUNT)).getAsLong()
+            );
+            significantTerms.add(term);
+        }
+        totalCount = significantTermsAggregation.has(String.valueOf(DOC_COUNT)) ? significantTermsAggregation.get(String.valueOf(DOC_COUNT)).getAsLong() : null;
+    }
+
+    /**
+     * @return total count of documents matching foreground aggregation if found, null otherwise
+     */
+    public Long getTotalCount() {
+        return totalCount;
+    }
+
+    public List<SignificantTerm> getSignificantTerms() {
+        return significantTerms;
+    }
+
+    public class SignificantTerm {
+        private String key;
+        private Long count;
+        private Double score;
+        private Long backgroundCount;
+
+        public SignificantTerm(String key, Long count, Double score, Long backgroundCount) {
+            this.key = key;
+            this.count = count;
+            this.score = score;
+            this.backgroundCount = backgroundCount;
+        }
+
+        public String getKey() {
+            return key;
+        }
+
+        public Long getCount() {
+            return count;
+        }
+
+        public Double getScore() {
+            return score;
+        }
+
+        public Long getBackgroundCount() {
+            return backgroundCount;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            SignificantTerm that = (SignificantTerm) o;
+
+            if (!backgroundCount.equals(that.backgroundCount)) {
+                return false;
+            }
+            if (!count.equals(that.count)) {
+                return false;
+            }
+            if (!key.equals(that.key)) {
+                return false;
+            }
+            if (!score.equals(that.score)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = key.hashCode();
+            result = 31 * result + count.hashCode();
+            result = 31 * result + score.hashCode();
+            result = 31 * result + backgroundCount.hashCode();
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        SignificantTermsAggregation that = (SignificantTermsAggregation) o;
+
+        if (!significantTerms.equals(that.significantTerms)) {
+            return false;
+        }
+        if (totalCount != null ? !totalCount.equals(that.totalCount) : that.totalCount != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = totalCount != null ? totalCount.hashCode() : 0;
+        result = 31 * result + significantTerms.hashCode();
+        return result;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -87,31 +89,23 @@ public class SignificantTermsAggregation extends Aggregation<SignificantTermsAgg
                 return false;
             }
 
-            SignificantTerm that = (SignificantTerm) o;
-
-            if (!backgroundCount.equals(that.backgroundCount)) {
-                return false;
-            }
-            if (!count.equals(that.count)) {
-                return false;
-            }
-            if (!key.equals(that.key)) {
-                return false;
-            }
-            if (!score.equals(that.score)) {
-                return false;
-            }
-
-            return true;
+            SignificantTerm rhs = (SignificantTerm) o;
+            return new EqualsBuilder()
+                    .append(getCount(), rhs.getCount())
+                    .append(getBackgroundCount(), rhs.getBackgroundCount())
+                    .append(getKey(), rhs.getKey())
+                    .append(getScore(), rhs.getScore())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = key.hashCode();
-            result = 31 * result + count.hashCode();
-            result = 31 * result + score.hashCode();
-            result = 31 * result + backgroundCount.hashCode();
-            return result;
+            return new HashCodeBuilder()
+                    .append(getCount())
+                    .append(getBackgroundCount())
+                    .append(getKey())
+                    .append(getScore())
+                    .toHashCode();
         }
     }
 
@@ -124,22 +118,18 @@ public class SignificantTermsAggregation extends Aggregation<SignificantTermsAgg
             return false;
         }
 
-        SignificantTermsAggregation that = (SignificantTermsAggregation) o;
-
-        if (!significantTerms.equals(that.significantTerms)) {
-            return false;
-        }
-        if (totalCount != null ? !totalCount.equals(that.totalCount) : that.totalCount != null) {
-            return false;
-        }
-
-        return true;
+        SignificantTermsAggregation rhs = (SignificantTermsAggregation) o;
+        return new EqualsBuilder()
+                .append(getSignificantTerms(), rhs.getSignificantTerms())
+                .append(getTotalCount(), rhs.getTotalCount())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = totalCount != null ? totalCount.hashCode() : 0;
-        result = 31 * result + significantTerms.hashCode();
-        return result;
+        return new HashCodeBuilder()
+                .append(getSignificantTerms())
+                .append(getTotalCount())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
@@ -1,0 +1,49 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public abstract class SingleValueAggregation <T extends SingleValueAggregation> extends Aggregation<T> {
+
+    private Double value;
+
+    protected SingleValueAggregation(String name, JsonObject singleValueAggregation) {
+        super(name, singleValueAggregation);
+        value = !singleValueAggregation.has(String.valueOf(VALUE)) || singleValueAggregation.get(String.valueOf(VALUE)).isJsonNull()?
+                null : singleValueAggregation.get(String.valueOf(VALUE)).getAsDouble();
+    }
+
+    /**
+     * @return value if it was found and not null, null otherwise
+     */
+    protected Double getValue() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SingleValueAggregation)) {
+            return false;
+        }
+
+        SingleValueAggregation that = (SingleValueAggregation) o;
+
+        if (value != null ? !value.equals(that.value) : that.value != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return value != null ? value.hashCode() : 0;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -33,17 +35,16 @@ public abstract class SingleValueAggregation <T extends SingleValueAggregation> 
             return false;
         }
 
-        SingleValueAggregation that = (SingleValueAggregation) o;
-
-        if (value != null ? !value.equals(that.value) : that.value != null) {
-            return false;
-        }
-
-        return true;
+        SingleValueAggregation rhs = (SingleValueAggregation) o;
+        return new EqualsBuilder()
+                .append(getValue(), rhs.getValue())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return value != null ? value.hashCode() : 0;
+        return new HashCodeBuilder()
+                .append(getValue())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
@@ -1,0 +1,108 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.AVG;
+import static io.searchbox.core.search.aggregation.AggregationField.COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.MAX;
+import static io.searchbox.core.search.aggregation.AggregationField.MIN;
+import static io.searchbox.core.search.aggregation.AggregationField.SUM;
+
+/**
+ * @author cfstout
+ */
+public class StatsAggregation<T extends StatsAggregation> extends Aggregation<T> {
+
+    public static final String TYPE = "stats";
+
+    private Long count;
+    private Double min;
+    private Double max;
+    private Double avg;
+    private Double sum;
+
+    public StatsAggregation(String name, JsonObject statsAggregation) {
+        super(name, statsAggregation);
+        this.count = statsAggregation.get(String.valueOf(COUNT)).getAsLong();
+        this.min = !statsAggregation.has(String.valueOf(MIN)) || statsAggregation.get(String.valueOf(MIN)).isJsonNull() ?
+            null : statsAggregation.get(String.valueOf(MIN)).getAsDouble();
+        this.max = !statsAggregation.has(String.valueOf(MAX)) || statsAggregation.get(String.valueOf(MAX)).isJsonNull() ?
+                null : statsAggregation.get(String.valueOf(MAX)).getAsDouble();
+        this.avg = !statsAggregation.has(String.valueOf(AVG)) || statsAggregation.get(String.valueOf(AVG)).isJsonNull() ?
+                null : statsAggregation.get(String.valueOf(AVG)).getAsDouble();
+        this.sum = !statsAggregation.has(String.valueOf(SUM)) || statsAggregation.get(String.valueOf(SUM)).isJsonNull() ?
+                null : statsAggregation.get(String.valueOf(SUM)).getAsDouble();
+    }
+
+    public Long getCount() {
+        return count;
+    }
+
+    /**
+     * @return Min if it was found and not null, null otherwise
+     */
+    public Double getMin() {
+        return min;
+    }
+
+    /**
+     * @return Max if it was found and not null, null otherwise
+     */
+    public Double getMax() {
+        return max;
+    }
+
+    /**
+     * @return Avg if it was found and not null, null otherwise
+     */
+    public Double getAvg() {
+        return avg;
+    }
+
+    /**
+     * @return Sum if it was found and not null, null otherwise
+     */
+    public Double getSum() {
+        return sum;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StatsAggregation that = (StatsAggregation) o;
+
+        if (avg != null ? !avg.equals(that.avg) : that.avg != null) {
+            return false;
+        }
+        if (!count.equals(that.count)) {
+            return false;
+        }
+        if (max != null ? !max.equals(that.max) : that.max != null) {
+            return false;
+        }
+        if (min != null ? !min.equals(that.min) : that.min != null) {
+            return false;
+        }
+        if (sum != null ? !sum.equals(that.sum) : that.sum != null) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = count.hashCode();
+        result = 31 * result + (min != null ? min.hashCode() : 0);
+        result = 31 * result + (max != null ? max.hashCode() : 0);
+        result = 31 * result + (avg != null ? avg.hashCode() : 0);
+        result = 31 * result + (sum != null ? sum.hashCode() : 0);
+        return result;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.AVG;
 import static io.searchbox.core.search.aggregation.AggregationField.COUNT;
@@ -75,34 +77,24 @@ public class StatsAggregation<T extends StatsAggregation> extends Aggregation<T>
             return false;
         }
 
-        StatsAggregation that = (StatsAggregation) o;
-
-        if (avg != null ? !avg.equals(that.avg) : that.avg != null) {
-            return false;
-        }
-        if (!count.equals(that.count)) {
-            return false;
-        }
-        if (max != null ? !max.equals(that.max) : that.max != null) {
-            return false;
-        }
-        if (min != null ? !min.equals(that.min) : that.min != null) {
-            return false;
-        }
-        if (sum != null ? !sum.equals(that.sum) : that.sum != null) {
-            return false;
-        }
-
-        return true;
+        StatsAggregation rhs = (StatsAggregation) o;
+        return new EqualsBuilder()
+                .append(getAvg(), rhs.getAvg())
+                .append(getCount(), rhs.getCount())
+                .append(getMax(), rhs.getMax())
+                .append(getMin(), rhs.getMin())
+                .append(getSum(), rhs.getSum())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = count.hashCode();
-        result = 31 * result + (min != null ? min.hashCode() : 0);
-        result = 31 * result + (max != null ? max.hashCode() : 0);
-        result = 31 * result + (avg != null ? avg.hashCode() : 0);
-        result = 31 * result + (sum != null ? sum.hashCode() : 0);
-        return result;
+        return new HashCodeBuilder()
+                .append(getCount())
+                .append(getAvg())
+                .append(getMax())
+                .append(getMin())
+                .append(getSum())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SumAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SumAggregation.java
@@ -1,0 +1,32 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class SumAggregation extends SingleValueAggregation<SumAggregation> {
+
+    public static final String TYPE = "sum";
+
+    public SumAggregation(String name, JsonObject sumAggregation) {
+        super(name, sumAggregation);
+    }
+
+    public Double getSum() {
+        return getValue();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof SumAggregation)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
@@ -2,6 +2,8 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -74,23 +76,19 @@ public class TermsAggregation extends Aggregation<TermsAggregation> {
                 return false;
             }
 
-            Bucket bucket = (Bucket) o;
-
-            if (!count.equals(bucket.count)) {
-                return false;
-            }
-            if (!name.equals(bucket.name)) {
-                return false;
-            }
-
-            return true;
+            Bucket rhs = (Bucket) o;
+            return new EqualsBuilder()
+                    .append(getName(), rhs.getName())
+                    .append(getCount(), rhs.getCount())
+                    .isEquals();
         }
 
         @Override
         public int hashCode() {
-            int result = name.hashCode();
-            result = 31 * result + count.hashCode();
-            return result;
+            return new HashCodeBuilder()
+                    .append(getCount())
+                    .append(getName())
+                    .toHashCode();
         }
     }
 
@@ -103,26 +101,20 @@ public class TermsAggregation extends Aggregation<TermsAggregation> {
             return false;
         }
 
-        TermsAggregation that = (TermsAggregation) o;
-
-        if (!buckets.equals(that.buckets)) {
-            return false;
-        }
-        if (!docCountErrorUpperBound.equals(that.docCountErrorUpperBound)) {
-            return false;
-        }
-        if (!sumOtherDocCount.equals(that.sumOtherDocCount)) {
-            return false;
-        }
-
-        return true;
+        TermsAggregation rhs = (TermsAggregation) o;
+        return new EqualsBuilder()
+                .append(getBuckets(), rhs.getBuckets())
+                .append(getDocCountErrorUpperBound(), rhs.getDocCountErrorUpperBound())
+                .append(getSumOtherDocCount(), rhs.getSumOtherDocCount())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        int result = docCountErrorUpperBound.hashCode();
-        result = 31 * result + sumOtherDocCount.hashCode();
-        result = 31 * result + buckets.hashCode();
-        return result;
+        return new HashCodeBuilder()
+                .append(getDocCountErrorUpperBound())
+                .append(getSumOtherDocCount())
+                .append(getBuckets())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
+import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT_ERROR_UPPER_BOUND;
+import static io.searchbox.core.search.aggregation.AggregationField.KEY;
+import static io.searchbox.core.search.aggregation.AggregationField.SUM_OTHER_DOC_COUNT;
+
+/**
+ * @author cfstout
+ */
+
+public class TermsAggregation extends Aggregation<TermsAggregation> {
+
+    public static final String TYPE = "terms";
+
+    private Long docCountErrorUpperBound;
+    private Long sumOtherDocCount;
+    private List<Bucket> buckets;
+
+    public TermsAggregation(String name, JsonObject termAggregation) {
+        super(name, termAggregation);
+        docCountErrorUpperBound = termAggregation.get(String.valueOf(DOC_COUNT_ERROR_UPPER_BOUND)).getAsLong();
+        sumOtherDocCount = termAggregation.get(String.valueOf(SUM_OTHER_DOC_COUNT)).getAsLong();
+        buckets = new ArrayList<Bucket>();
+        for(JsonElement bucketv : termAggregation.get(String.valueOf(BUCKETS)).getAsJsonArray()) {
+            JsonObject bucket = (JsonObject) bucketv;
+            Bucket entry = new Bucket(bucket.get(String.valueOf(KEY)).getAsString(), bucket.get(String.valueOf(DOC_COUNT)).getAsInt());
+            buckets.add(entry);
+        }
+    }
+
+    public Long getDocCountErrorUpperBound() {
+        return docCountErrorUpperBound;
+    }
+
+    public Long getSumOtherDocCount() {
+        return sumOtherDocCount;
+    }
+
+    public List<Bucket> getBuckets() {
+        return buckets;
+    }
+
+    public class Bucket {
+        private String name;
+        private Integer count;
+
+        public Bucket(String name, Integer count) {
+            this.name = name;
+            this.count = count;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public Integer getCount() {
+            return count;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+
+            Bucket bucket = (Bucket) o;
+
+            if (!count.equals(bucket.count)) {
+                return false;
+            }
+            if (!name.equals(bucket.name)) {
+                return false;
+            }
+
+            return true;
+        }
+
+        @Override
+        public int hashCode() {
+            int result = name.hashCode();
+            result = 31 * result + count.hashCode();
+            return result;
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        TermsAggregation that = (TermsAggregation) o;
+
+        if (!buckets.equals(that.buckets)) {
+            return false;
+        }
+        if (!docCountErrorUpperBound.equals(that.docCountErrorUpperBound)) {
+            return false;
+        }
+        if (!sumOtherDocCount.equals(that.sumOtherDocCount)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = docCountErrorUpperBound.hashCode();
+        result = 31 * result + sumOtherDocCount.hashCode();
+        result = 31 * result + buckets.hashCode();
+        return result;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
@@ -1,6 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -31,17 +33,16 @@ public class ValueCountAggregation extends Aggregation<ValueCountAggregation> {
             return false;
         }
 
-        ValueCountAggregation that = (ValueCountAggregation) o;
-
-        if (!valueCount.equals(that.valueCount)) {
-            return false;
-        }
-
-        return true;
+        ValueCountAggregation rhs = (ValueCountAggregation) o;
+        return new EqualsBuilder()
+                .append(getValueCount(), rhs.getValueCount())
+                .isEquals();
     }
 
     @Override
     public int hashCode() {
-        return valueCount.hashCode();
+        return new HashCodeBuilder()
+                .append(getValueCount())
+                .toHashCode();
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
@@ -1,0 +1,47 @@
+package io.searchbox.core.search.aggregation;
+
+import com.google.gson.JsonObject;
+
+import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
+
+/**
+ * @author cfstout
+ */
+public class ValueCountAggregation extends Aggregation<ValueCountAggregation> {
+
+    public static final String TYPE = "value_count";
+
+    private Long valueCount;
+
+    public ValueCountAggregation(String name, JsonObject valueCountAggregation) {
+        super(name, valueCountAggregation);
+        valueCount = valueCountAggregation.get(String.valueOf(VALUE)).getAsLong();
+    }
+
+    public Long getValueCount() {
+        return valueCount;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ValueCountAggregation that = (ValueCountAggregation) o;
+
+        if (!valueCount.equals(that.valueCount)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return valueCount.hashCode();
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/AvgAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/AvgAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class AvgAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "avg_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetAvgAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"avg1\" : {\n" +
+                "            \"avg\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        AvgAggregation average = result.getAggregations().getAvgAggregation("avg1");
+        assertEquals("avg1", average.getName());
+        assertEquals(new Double(2.5) , average.getAvg());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("avg1", AvgAggregation.class);
+        assertTrue(aggregation instanceof AvgAggregation);
+        AvgAggregation averageByType = (AvgAggregation) aggregation;
+        assertEquals(average, averageByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("avg1", AvgAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof AvgAggregation);
+        AvgAggregation averageWithMap = (AvgAggregation) aggregations.get(0);
+        assertEquals(average, averageWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"avg1\" : {\n" +
+                "            \"avg\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        AvgAggregation average = result.getAggregations().getAvgAggregation("avg1");
+        assertNull(average.getAvg());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("avg1", AvgAggregation.class);
+        assertTrue(aggregation instanceof AvgAggregation);
+        AvgAggregation averageByType = (AvgAggregation) aggregation;
+        assertEquals(average, averageByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("avg1", AvgAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof AvgAggregation);
+        AvgAggregation averageWithMap = (AvgAggregation) aggregations.get(0);
+        assertEquals(average, averageWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/AvgAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/AvgAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class AvgAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "avg_aggregation";
@@ -32,11 +32,11 @@ public class AvgAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class AvgAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "cardinality_aggregation";
@@ -32,11 +32,11 @@ public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"doc_id\":\"abc\"}");
         index(INDEX, TYPE, null, "{\"doc_id\":\"def\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"doc_id\":\"abc\"}");
         index(INDEX, TYPE, null, "{\"doc_id\":\"def\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "cardinality_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetCardinalityAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"doc_id\":\"abc\"}");
+        index(INDEX, TYPE, null, "{\"doc_id\":\"def\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"card1\" : {\n" +
+                "            \"cardinality\" : {\n" +
+                "                \"field\" : \"doc_id\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        CardinalityAggregation cardinality = result.getAggregations().getCardinalityAggregation("card1");
+        assertEquals("card1", cardinality.getName());
+        assertEquals(new Long(2) , cardinality.getCardinality());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("card1", CardinalityAggregation.class);
+        assertTrue(aggregation instanceof CardinalityAggregation);
+        CardinalityAggregation cardinalityByType = (CardinalityAggregation) aggregation;
+        assertEquals(cardinality, cardinalityByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("card1", CardinalityAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof CardinalityAggregation);
+        CardinalityAggregation cardinalityWithMap = (CardinalityAggregation) aggregations.get(0);
+        assertEquals(cardinalityWithMap, cardinalityByType);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"doc_id\":\"abc\"}");
+        index(INDEX, TYPE, null, "{\"doc_id\":\"def\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"card1\" : {\n" +
+                "            \"cardinality\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        CardinalityAggregation cardinality = result.getAggregations().getCardinalityAggregation("card1");
+        assertTrue(0L == cardinality.getCardinality());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("card1", CardinalityAggregation.class);
+        assertTrue(aggregation instanceof CardinalityAggregation);
+        CardinalityAggregation cardinalityByType = (CardinalityAggregation) aggregation;
+        assertEquals(cardinality, cardinalityByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("card1", CardinalityAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof CardinalityAggregation);
+        CardinalityAggregation cardinalityWithMap = (CardinalityAggregation) aggregations.get(0);
+        assertEquals(cardinalityWithMap, cardinalityByType);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/DateHistogramAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/DateHistogramAggregationIntegrationTest.java
@@ -1,0 +1,140 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class DateHistogramAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "date_histogram_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetDateHistogramAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"delivery\":{\"store\":true,\"type\":\"date\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"histo1\" : {\n" +
+                "            \"date_histogram\" : {\n" +
+                "                \"field\" : \"delivery\",\n" +
+                "                \"interval\" : \"day\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        DateHistogramAggregation dateHistogram = result.getAggregations().getDateHistogramAggregation("histo1");
+        assertEquals("histo1", dateHistogram.getName());
+        assertEquals(3, dateHistogram.getDateHistograms().size());
+        assertTrue(1L == dateHistogram.getDateHistograms().get(0).getCount());
+        assertTrue(1359676800000L == dateHistogram.getDateHistograms().get(0).getTime());
+        assertTrue(1L == dateHistogram.getDateHistograms().get(1).getCount());
+        assertTrue(1359849600000L == dateHistogram.getDateHistograms().get(1).getTime());
+        assertTrue(2L == dateHistogram.getDateHistograms().get(2).getCount());
+        assertTrue(1359936000000L == dateHistogram.getDateHistograms().get(2).getTime());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("histo1", DateHistogramAggregation.class);
+        assertTrue(aggregation instanceof DateHistogramAggregation);
+        DateHistogramAggregation dateHistogramByType = (DateHistogramAggregation) aggregation;
+        assertEquals(dateHistogram, dateHistogramByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("histo1", DateHistogramAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof DateHistogramAggregation);
+        DateHistogramAggregation dateHistogramWithMap = (DateHistogramAggregation) aggregations.get(0);
+        assertEquals(dateHistogram, dateHistogramWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"delivery\":{\"store\":true,\"type\":\"date\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"histo1\" : {\n" +
+                "            \"date_histogram\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"interval\" : \"day\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        DateHistogramAggregation dateHistogram = result.getAggregations().getDateHistogramAggregation("histo1");
+        assertTrue(dateHistogram.getDateHistograms().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("histo1", DateHistogramAggregation.class);
+        assertTrue(aggregation instanceof DateHistogramAggregation);
+        DateHistogramAggregation dateHistogramByType = (DateHistogramAggregation) aggregation;
+        assertEquals(dateHistogram, dateHistogramByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("histo1", DateHistogramAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof DateHistogramAggregation);
+        DateHistogramAggregation dateHistogramWithMap = (DateHistogramAggregation) aggregations.get(0);
+        assertEquals(dateHistogram, dateHistogramWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/DateHistogramAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/DateHistogramAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class DateHistogramAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "date_histogram_aggregation";
@@ -32,13 +32,13 @@ public class DateHistogramAggregationIntegrationTest extends AbstractIntegration
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -94,13 +94,13 @@ public class DateHistogramAggregationIntegrationTest extends AbstractIntegration
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
@@ -1,0 +1,167 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class DateRangeAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "date_range_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetDateRangeAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"delivery\":{\"store\":true,\"type\":\"date\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"date_range1\" : {\n" +
+                "            \"date_range\" : {\n" +
+                "                \"field\" : \"delivery\",\n" +
+                "                \"format\" : \"yyy-MM-dd\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": \"2013-02-03||/d+1m\"},\n" +
+                "                   { \"from\": \"2013-02-03||/d+1m\"}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        DateRangeAggregation dateRange = result.getAggregations().getDateRangeAggregation("date_range1");
+        assertEquals("date_range1", dateRange.getName());
+        assertEquals(2, dateRange.getRanges().size());
+
+        assertTrue(2L == dateRange.getRanges().get(0).getCount());
+        assertNull(dateRange.getRanges().get(0).getFrom());
+        assertNull(dateRange.getRanges().get(0).getFromAsString());
+        assertEquals(Double.valueOf("1.35984966E12"), dateRange.getRanges().get(0).getTo());
+        assertEquals("2013-02-03", dateRange.getRanges().get(0).getToAsString());
+
+        assertTrue(2L == dateRange.getRanges().get(1).getCount());
+        assertNull(dateRange.getRanges().get(1).getTo());
+        assertNull(dateRange.getRanges().get(1).getToAsString());
+        assertEquals(Double.valueOf("1.35984966E12"), dateRange.getRanges().get(1).getFrom());
+        assertEquals("2013-02-03", dateRange.getRanges().get(1).getFromAsString());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("date_range1", DateRangeAggregation.class);
+        assertTrue(aggregation instanceof DateRangeAggregation);
+        DateRangeAggregation dateRangeByType = (DateRangeAggregation) aggregation;
+        assertEquals(dateRange, dateRangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("date_range1", DateRangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof DateRangeAggregation);
+        DateRangeAggregation dateRangeWithMap = (DateRangeAggregation) aggregations.get(0);
+        assertEquals(dateRange, dateRangeWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"delivery\":{\"store\":true,\"type\":\"date\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
+        index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"date_range1\" : {\n" +
+                "            \"date_range\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"format\" : \"yyy-MM-dd\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": \"2013-02-03||/d+1m\"},\n" +
+                "                   { \"from\": \"2013-02-03||/d+1m\"}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        DateRangeAggregation dateRange = result.getAggregations().getDateRangeAggregation("date_range1");
+        assertEquals("date_range1", dateRange.getName());
+        assertEquals(2, dateRange.getRanges().size());
+
+        assertTrue(0L == dateRange.getRanges().get(0).getCount());
+        assertNull(dateRange.getRanges().get(0).getFrom());
+        assertNull(dateRange.getRanges().get(0).getFromAsString());
+        assertEquals(Double.valueOf("1.35984966E12"), dateRange.getRanges().get(0).getTo());
+        assertEquals("2013-02-03", dateRange.getRanges().get(0).getToAsString());
+
+        assertTrue(0L == dateRange.getRanges().get(1).getCount());
+        assertNull(dateRange.getRanges().get(1).getTo());
+        assertNull(dateRange.getRanges().get(1).getToAsString());
+        assertEquals(Double.valueOf("1.35984966E12"), dateRange.getRanges().get(1).getFrom());
+        assertEquals("2013-02-03", dateRange.getRanges().get(1).getFromAsString());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("date_range1", DateRangeAggregation.class);
+        assertTrue(aggregation instanceof DateRangeAggregation);
+        DateRangeAggregation dateRangeByType = (DateRangeAggregation) aggregation;
+        assertEquals(dateRange, dateRangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("date_range1", DateRangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof DateRangeAggregation);
+        DateRangeAggregation dateRangeWithMap = (DateRangeAggregation) aggregations.get(0);
+        assertEquals(dateRange, dateRangeWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class DateRangeAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "date_range_aggregation";
@@ -32,13 +32,13 @@ public class DateRangeAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -104,13 +104,13 @@ public class DateRangeAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-04\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-01\"}");
         index(INDEX, TYPE, null, "{\"delivery\":\"2013-02-03\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class ExtendedStatsAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "extended_stats_aggregation";
@@ -32,11 +32,11 @@ public class ExtendedStatsAggregationIntegrationTest extends AbstractIntegration
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -92,11 +92,11 @@ public class ExtendedStatsAggregationIntegrationTest extends AbstractIntegration
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregationIntegrationTest.java
@@ -1,0 +1,144 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class ExtendedStatsAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "extended_stats_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetExtendedStatsAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"extended_stats1\" : {\n" +
+                "            \"extended_stats\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        ExtendedStatsAggregation extendedStats = result.getAggregations().getExtendedStatsAggregation("extended_stats1");
+        assertEquals("extended_stats1", extendedStats.getName());
+        assertEquals(new Double(2.5) , extendedStats.getAvg());
+        assertTrue(2L == extendedStats.getCount());
+        assertEquals(new Double(3) , extendedStats.getMax());
+        assertEquals(new Double(2) , extendedStats.getMin());
+        assertEquals(new Double(5) , extendedStats.getSum());
+        assertEquals(new Double(.5), extendedStats.getStdDeviation());
+        assertEquals(new Double(13), extendedStats.getSumOfSquares());
+        assertEquals(new Double(.25), extendedStats.getVariance());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("extended_stats1", ExtendedStatsAggregation.class);
+        assertTrue(aggregation instanceof ExtendedStatsAggregation);
+        ExtendedStatsAggregation extendedStatsByType = (ExtendedStatsAggregation) aggregation;
+        assertEquals(extendedStats, extendedStatsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("extended_stats1", ExtendedStatsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ExtendedStatsAggregation);
+        ExtendedStatsAggregation extendedStatsWithMap = (ExtendedStatsAggregation) aggregations.get(0);
+        assertEquals(extendedStats, extendedStatsWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"extended_stats1\" : {\n" +
+                "            \"extended_stats\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        ExtendedStatsAggregation extendedStats = result.getAggregations().getExtendedStatsAggregation("extended_stats1");
+        assertEquals("extended_stats1", extendedStats.getName());
+        assertNull(extendedStats.getAvg());
+        assertTrue(0L == extendedStats.getCount());
+        assertNull(extendedStats.getMax());
+        assertNull(extendedStats.getMin());
+        assertNull(extendedStats.getSum());
+        assertNull(extendedStats.getStdDeviation());
+        assertNull(extendedStats.getSumOfSquares());
+        assertNull(extendedStats.getVariance());
+
+
+        Aggregation aggregation = result.getAggregations().getAggregation("extended_stats1", ExtendedStatsAggregation.class);
+        assertTrue(aggregation instanceof ExtendedStatsAggregation);
+        ExtendedStatsAggregation extendedStatsByType = (ExtendedStatsAggregation) aggregation;
+        assertEquals(extendedStats, extendedStatsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("extended_stats1", ExtendedStatsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ExtendedStatsAggregation);
+        ExtendedStatsAggregation extendedStatsWithMap = (ExtendedStatsAggregation) aggregations.get(0);
+        assertEquals(extendedStats, extendedStatsWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/FilterAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/FilterAggregationIntegrationTest.java
@@ -1,0 +1,77 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class FilterAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "filter_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetFilterAggregation()
+            throws IOException {
+
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        index(INDEX, TYPE, null, "{\"num\":4}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"filter1\" : {\n" +
+                "            \"filter\" : { \"range\" : { \"num\" : { \"gt\" :  2 } } }" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        FilterAggregation filter = result.getAggregations().getFilterAggregation("filter1");
+        assertEquals("filter1", filter.getName());
+        assertTrue(2L == filter.getCount());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("filter1", FilterAggregation.class);
+        assertTrue(aggregation instanceof FilterAggregation);
+        FilterAggregation filterByType = (FilterAggregation) aggregation;
+        assertEquals(filter, filterByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("filter1", FilterAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof FilterAggregation);
+        FilterAggregation filterWithMap = (FilterAggregation) aggregations.get(0);
+        assertEquals(filter, filterWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/FilterAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/FilterAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class FilterAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "filter_aggregation";
@@ -33,12 +33,12 @@ public class FilterAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         index(INDEX, TYPE, null, "{\"num\":4}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/FiltersAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/FiltersAggregationIntegrationTest.java
@@ -1,0 +1,144 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class FiltersAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "filters_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetFiltersAggregation()
+            throws IOException {
+
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"msg\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"error\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"other\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"filters1\" : {\n" +
+                "            \"filters\" : {\n" +
+                "               \"filters\" : {\n" +
+                "                   \"errors\" : { \"term\" : { \"msg\" : \"error\"}},\n" +
+                "                   \"warnings\" : { \"term\" : { \"msg\" : \"warn\"}}\n" +
+                "               }\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        FiltersAggregation filters = result.getAggregations().getFiltersAggregation("filters1");
+        assertEquals("filters1", filters.getName());
+        assertTrue(1L == filters.getCounts().get("errors"));
+        assertTrue(2L == filters.getCounts().get("warnings"));
+
+        Aggregation aggregation = result.getAggregations().getAggregation("filters1", FiltersAggregation.class);
+        assertTrue(aggregation instanceof FiltersAggregation);
+        FiltersAggregation filtersByType = (FiltersAggregation) aggregation;
+        assertEquals(filters, filtersByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("filters1", FiltersAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof FiltersAggregation);
+        FiltersAggregation filtersWithMap = (FiltersAggregation) aggregations.get(0);
+        assertEquals(filters, filtersWithMap);
+    }
+
+    @Test
+    public void testGetAnonymousFiltersAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"msg\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"error\"}");
+        index(INDEX, TYPE, null, "{\"msg\":\"other\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"filters1\" : {\n" +
+                "            \"filters\" : {\n" +
+                "               \"filters\" : [\n" +
+                "                   { \"term\" : { \"msg\" : \"error\"}},\n" +
+                "                   { \"term\" : { \"msg\" : \"warn\"}}\n" +
+                "               ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        FiltersAggregation filters = result.getAggregations().getFiltersAggregation("filters1");
+        assertEquals("filters1", filters.getName());
+        assertEquals(2, filters.getCountList().size());
+        assertTrue(1L == filters.getCountList().get(0));
+        assertTrue(2L == filters.getCountList().get(1));
+
+        Aggregation aggregation = result.getAggregations().getAggregation("filters1", FiltersAggregation.class);
+        assertTrue(aggregation instanceof FiltersAggregation);
+        FiltersAggregation filtersByType = (FiltersAggregation) aggregation;
+        assertEquals(filters, filtersByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("filters1", FiltersAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof FiltersAggregation);
+        FiltersAggregation filtersWithMap = (FiltersAggregation) aggregations.get(0);
+        assertEquals(filters, filtersWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/FiltersAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/FiltersAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class FiltersAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "filters_aggregation";
@@ -33,13 +33,13 @@ public class FiltersAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"error\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"other\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -92,13 +92,13 @@ public class FiltersAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"warn\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"error\"}");
         index(INDEX, TYPE, null, "{\"msg\":\"other\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeoBoundsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeoBoundsAggregationIntegrationTest.java
@@ -1,0 +1,138 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class GeoBoundsAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "geo_bounds_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGeoBoundsAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 40.12,\"lon\" : -71.34},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 38.54,\"lon\" : -71.78},\"tag\" : [\"gas\", \"food\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 41.23,\"lon\" : -70.67},\"tag\" : [\"gas\"]}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match\" : { \"tag\" : \"gas\" }\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"viewport\" : {\n" +
+                "            \"geo_bounds\" : {\n" +
+                "                \"field\" : \"location\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        GeoBoundsAggregation geoBounds = result.getAggregations().getGeoBoundsAggregation("viewport");
+        assertEquals("viewport", geoBounds.getName());
+        assertEquals(new Double(38.54), geoBounds.getBottomRightLat());
+        assertEquals(new Double(-70.67), geoBounds.getBottomRightLon());
+        assertEquals(new Double(41.23), geoBounds.getTopLeftLat());
+        assertEquals(new Double(-71.78), geoBounds.getTopLeftLon());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("viewport", GeoBoundsAggregation.class);
+        assertTrue(aggregation instanceof GeoBoundsAggregation);
+        GeoBoundsAggregation geoBoundsByType = (GeoBoundsAggregation) aggregation;
+        assertEquals(geoBounds, geoBoundsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("viewport", GeoBoundsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeoBoundsAggregation);
+        GeoBoundsAggregation geoBoundsWithMap = (GeoBoundsAggregation) aggregations.get(0);
+        assertEquals(geoBounds, geoBoundsWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 40.12,\"lon\" : -71.34},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 38.54,\"lon\" : -71.78},\"tag\" : [\"gas\", \"food\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 41.23,\"lon\" : -70.67},\"tag\" : [\"gas\"]}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match\" : { \"tag\" : \"gas\" }\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"viewport\" : {\n" +
+                "            \"geo_bounds\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        GeoBoundsAggregation geoBounds = result.getAggregations().getGeoBoundsAggregation("viewport");
+        assertEquals("viewport", geoBounds.getName());
+        assertNull(geoBounds.getBottomRightLat());
+        assertNull(geoBounds.getBottomRightLon());
+        assertNull(geoBounds.getTopLeftLat());
+        assertNull(geoBounds.getTopLeftLon());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("viewport", GeoBoundsAggregation.class);
+        assertTrue(aggregation instanceof GeoBoundsAggregation);
+        GeoBoundsAggregation geoBoundsByType = (GeoBoundsAggregation) aggregation;
+        assertEquals(geoBounds, geoBoundsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("viewport", GeoBoundsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeoBoundsAggregation);
+        GeoBoundsAggregation geoBoundsWithMap = (GeoBoundsAggregation) aggregations.get(0);
+        assertEquals(geoBounds, geoBoundsWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeoBoundsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeoBoundsAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class GeoBoundsAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "geo_bounds_aggregation";
@@ -32,12 +32,12 @@ public class GeoBoundsAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 40.12,\"lon\" : -71.34},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 38.54,\"lon\" : -71.78},\"tag\" : [\"gas\", \"food\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 41.23,\"lon\" : -70.67},\"tag\" : [\"gas\"]}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -90,12 +90,12 @@ public class GeoBoundsAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 40.12,\"lon\" : -71.34},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 38.54,\"lon\" : -71.78},\"tag\" : [\"gas\", \"food\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 41.23,\"lon\" : -70.67},\"tag\" : [\"gas\"]}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeoDistanceAggregationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeoDistanceAggregationTest.java
@@ -1,0 +1,181 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "geo_distance_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetGeoDistanceAggregationWithProperName()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"rings\" : {\n" +
+                "            \"geo_distance\" : {\n" +
+                "                \"field\" : \"location\",\n" +
+                "                \"origin\" : {\n" +
+                "                    \"lat\": 30.274707,\n" +
+                "                    \"lon\": -97.740527\n" +
+                "                },\n" +
+                "                \"unit\" : \"mi\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\" : 5 }, \n" +
+                "                   { \"from\" : 5, \"to\" : 7 }, \n" +
+                "                   { \"from\" : 7} \n" +
+                "                ]\n " +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        GeoDistanceAggregation geoDistance = result.getAggregations().getGeoDistanceAggregation("rings");
+        assertEquals("rings", geoDistance.getName());
+        assertEquals(3, geoDistance.getGeoDistances().size());
+
+        assertTrue(1L == geoDistance.getGeoDistances().get(0).getCount());
+        assertEquals(new Double(5), geoDistance.getGeoDistances().get(0).getTo());
+        assertEquals(new Double(0), geoDistance.getGeoDistances().get(0).getFrom());
+
+        assertTrue(3L == geoDistance.getGeoDistances().get(1).getCount());
+        assertEquals(new Double(5), geoDistance.getGeoDistances().get(1).getFrom());
+        assertEquals(new Double(7), geoDistance.getGeoDistances().get(1).getTo());
+
+        assertTrue(1L == geoDistance.getGeoDistances().get(2).getCount());
+        assertEquals(new Double(7), geoDistance.getGeoDistances().get(2).getFrom());
+        assertNull(geoDistance.getGeoDistances().get(2).getTo());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("rings", GeoDistanceAggregation.class);
+        assertTrue(aggregation instanceof GeoDistanceAggregation);
+        GeoDistanceAggregation geoDistanceByName = (GeoDistanceAggregation) aggregation;
+        assertEquals(geoDistance, geoDistanceByName);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("rings", GeoDistanceAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeoDistanceAggregation);
+        GeoDistanceAggregation geoDistanceWithMap = (GeoDistanceAggregation) aggregations.get(0);
+        assertEquals(geoDistance, geoDistanceWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
+        refresh();
+
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"rings\" : {\n" +
+                "            \"geo_distance\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"origin\" : {\n" +
+                "                    \"lat\": 30.274707,\n" +
+                "                    \"lon\": -97.740527\n" +
+                "                },\n" +
+                "                \"unit\" : \"mi\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\" : 5 }, \n" +
+                "                   { \"from\" : 5, \"to\" : 7 }, \n" +
+                "                   { \"from\" : 7} \n" +
+                "                ]\n " +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        GeoDistanceAggregation geoDistance = result.getAggregations().getGeoDistanceAggregation("rings");
+        assertEquals("rings", geoDistance.getName());
+        assertEquals(3, geoDistance.getGeoDistances().size());
+
+        assertTrue(0L == geoDistance.getGeoDistances().get(0).getCount());
+        assertEquals(new Double(5), geoDistance.getGeoDistances().get(0).getTo());
+        assertEquals(new Double(0), geoDistance.getGeoDistances().get(0).getFrom());
+
+        assertTrue(0L == geoDistance.getGeoDistances().get(1).getCount());
+        assertEquals(new Double(5), geoDistance.getGeoDistances().get(1).getFrom());
+        assertEquals(new Double(7), geoDistance.getGeoDistances().get(1).getTo());
+
+        assertTrue(0L == geoDistance.getGeoDistances().get(2).getCount());
+        assertEquals(new Double(7), geoDistance.getGeoDistances().get(2).getFrom());
+        assertNull(geoDistance.getGeoDistances().get(2).getTo());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("rings", GeoDistanceAggregation.class);
+        assertTrue(aggregation instanceof GeoDistanceAggregation);
+        GeoDistanceAggregation geoDistanceByName = (GeoDistanceAggregation) aggregation;
+        assertEquals(geoDistance, geoDistanceByName);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("rings", GeoDistanceAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeoDistanceAggregation);
+        GeoDistanceAggregation geoDistanceWithMap = (GeoDistanceAggregation) aggregations.get(0);
+        assertEquals(geoDistance, geoDistanceWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeoDistanceAggregationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeoDistanceAggregationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "geo_distance_aggregation";
@@ -32,7 +32,6 @@ public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
@@ -40,6 +39,7 @@ public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -110,7 +110,6 @@ public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
@@ -118,6 +117,7 @@ public class GeoDistanceAggregationTest extends AbstractIntegrationTest {
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
         refresh();
+        ensureSearchable(INDEX);
 
 
         String query = "{\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeohashGridAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeohashGridAggregationIntegrationTest.java
@@ -1,0 +1,148 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "geohash_grid_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetGeoDistanceAggregationWithProperName()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"grid\" : {\n" +
+                "            \"geohash_grid\" : {\n" +
+                "                \"field\" : \"location\",\n" +
+                "                \"precision\" : 5\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        GeohashGridAggregation geohashGrid = result.getAggregations().getGeohashGridAggregation("grid");
+        assertEquals("grid", geohashGrid.getName());
+        assertEquals(3, geohashGrid.getGeohashGrids().size());
+
+        assertTrue(3L == geohashGrid.getGeohashGrids().get(0).getCount());
+        assertEquals("9v6kw", geohashGrid.getGeohashGrids().get(0).getKey());
+
+        assertTrue(1L == geohashGrid.getGeohashGrids().get(1).getCount());
+        assertEquals("9v6kz", geohashGrid.getGeohashGrids().get(1).getKey());
+
+        assertTrue(1L == geohashGrid.getGeohashGrids().get(2).getCount());
+        assertEquals("9v6kp", geohashGrid.getGeohashGrids().get(2).getKey());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("grid", GeohashGridAggregation.class);
+        assertTrue(aggregation instanceof GeohashGridAggregation);
+        GeohashGridAggregation geohashGridByName = (GeohashGridAggregation) aggregation;
+        assertEquals(geohashGrid, geohashGridByName);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("grid", GeohashGridAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeohashGridAggregation);
+        GeohashGridAggregation geohashGridWithMap = (GeohashGridAggregation) aggregations.get(0);
+        assertEquals(geohashGrid, geohashGridWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"location\":{\"store\":true,\"type\":\"geo_point\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
+        index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
+        refresh();
+
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"grid\" : {\n" +
+                "            \"geohash_grid\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"precision\" : 5\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        GeohashGridAggregation geohashGrid = result.getAggregations().getGeohashGridAggregation("grid");
+        assertEquals("grid", geohashGrid.getName());
+        assertTrue(geohashGrid.getGeohashGrids().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("grid", GeohashGridAggregation.class);
+        assertTrue(aggregation instanceof GeohashGridAggregation);
+        GeohashGridAggregation geohashGridByName = (GeohashGridAggregation) aggregation;
+        assertEquals(geohashGrid, geohashGridByName);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("grid", GeohashGridAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof GeohashGridAggregation);
+        GeohashGridAggregation geohashGridWithMap = (GeohashGridAggregation) aggregations.get(0);
+        assertEquals(geohashGrid, geohashGridWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/GeohashGridAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/GeohashGridAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "geohash_grid_aggregation";
@@ -32,7 +32,6 @@ public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
@@ -40,6 +39,7 @@ public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTe
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -98,7 +98,6 @@ public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.337991,\"lon\" : -97.807305},\"tag\" : [\"food\", \"family\"]}");
@@ -106,6 +105,7 @@ public class GeohashGridAggregationIntegrationTest extends AbstractIntegrationTe
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.400026, \"lon\" : -97.737343 } }");
         index(INDEX, TYPE, null, "{\"location\" : {\"lat\" : 30.257877, \"lon\" : -97.738726 } }");
         refresh();
+        ensureSearchable(INDEX);
 
 
         String query = "{\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/HistogramAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/HistogramAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class HistogramAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "histogram_aggregation";
@@ -32,13 +32,13 @@ public class HistogramAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\": 17}");
         index(INDEX, TYPE, null, "{\"num\":24}");
         index(INDEX, TYPE, null, "{\"num\":42}");
         index(INDEX, TYPE, null, "{\"num\":16}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -97,13 +97,13 @@ public class HistogramAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\": 17}");
         index(INDEX, TYPE, null, "{\"num\":24}");
         index(INDEX, TYPE, null, "{\"num\":42}");
         index(INDEX, TYPE, null, "{\"num\":16}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/HistogramAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/HistogramAggregationIntegrationTest.java
@@ -1,0 +1,143 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class HistogramAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "histogram_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetHistogramAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\": 17}");
+        index(INDEX, TYPE, null, "{\"num\":24}");
+        index(INDEX, TYPE, null, "{\"num\":42}");
+        index(INDEX, TYPE, null, "{\"num\":16}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"histo1\" : {\n" +
+                "            \"histogram\" : {\n" +
+                "                \"field\" : \"num\",\n" +
+                "                \"interval\" : 20\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        HistogramAggregation histogram = result.getAggregations().getHistogramAggregation("histo1");
+        assertEquals("histo1", histogram.getName());
+        assertEquals(3, histogram.getHistograms().size());
+
+        assertTrue(2L == histogram.getHistograms().get(0).getCount());
+        assertTrue(0L == histogram.getHistograms().get(0).getKey());
+
+        assertTrue(1L == histogram.getHistograms().get(1).getCount());
+        assertTrue(20L == histogram.getHistograms().get(1).getKey());
+
+        assertTrue(1L == histogram.getHistograms().get(2).getCount());
+        assertTrue(40L == histogram.getHistograms().get(2).getKey());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("histo1", HistogramAggregation.class);
+        assertTrue(aggregation instanceof HistogramAggregation);
+        HistogramAggregation histogramByType = (HistogramAggregation) aggregation;
+        assertEquals(histogram, histogramByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("histo1", HistogramAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof HistogramAggregation);
+        HistogramAggregation histogramWithMap = (HistogramAggregation) aggregations.get(0);
+        assertEquals(histogram, histogramWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\": 17}");
+        index(INDEX, TYPE, null, "{\"num\":24}");
+        index(INDEX, TYPE, null, "{\"num\":42}");
+        index(INDEX, TYPE, null, "{\"num\":16}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"histo1\" : {\n" +
+                "            \"histogram\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"interval\" : 20\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        HistogramAggregation histogram = result.getAggregations().getHistogramAggregation("histo1");
+        assertTrue(histogram.getHistograms().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("histo1", HistogramAggregation.class);
+        assertTrue(aggregation instanceof HistogramAggregation);
+        HistogramAggregation histogramByType = (HistogramAggregation) aggregation;
+        assertEquals(histogram, histogramByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("histo1", HistogramAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof HistogramAggregation);
+        HistogramAggregation histogramWithMap = (HistogramAggregation) aggregations.get(0);
+        assertEquals(histogram, histogramWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
@@ -1,0 +1,165 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "ipv4_range_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetIpv4RangRangeAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"address\":{\"store\":true,\"type\":\"ip\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.23\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.1\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.1.0\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.123\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"ipv4_range1\" : {\n" +
+                "            \"ip_range\" : {\n" +
+                "                \"field\" : \"address\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": \"10.0.0.25\"},\n" +
+                "                   { \"from\": \"10.0.0.25\"}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        Ipv4RangeAggregation ipv4Range = result.getAggregations().getIpv4RangeAggregation("ipv4_range1");
+        assertEquals("ipv4_range1", ipv4Range.getName());
+        assertEquals(2, ipv4Range.getRanges().size());
+
+        assertTrue(2L == ipv4Range.getRanges().get(0).getCount());
+        assertNull(ipv4Range.getRanges().get(0).getFrom());
+        assertNull(ipv4Range.getRanges().get(0).getFromAsString());
+        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getRanges().get(0).getTo());
+        assertEquals("10.0.0.25", ipv4Range.getRanges().get(0).getToAsString());
+
+        assertTrue(2L == ipv4Range.getRanges().get(1).getCount());
+        assertNull(ipv4Range.getRanges().get(1).getTo());
+        assertNull(ipv4Range.getRanges().get(1).getToAsString());
+        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getRanges().get(1).getFrom());
+        assertEquals("10.0.0.25", ipv4Range.getRanges().get(1).getFromAsString());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("ipv4_range1", Ipv4RangeAggregation.class);
+        assertTrue(aggregation instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeByType = (Ipv4RangeAggregation) aggregation;
+        assertEquals(ipv4Range, ipv4RangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("ipv4_range1", Ipv4RangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeWithMap = (Ipv4RangeAggregation) aggregations.get(0);
+        assertEquals(ipv4Range, ipv4RangeWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"address\":{\"store\":true,\"type\":\"ip\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.23\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.1\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.1.0\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.123\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"ipv4_range1\" : {\n" +
+                "            \"ip_range\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": \"10.0.0.25\"},\n" +
+                "                   { \"from\": \"10.0.0.25\"}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        Ipv4RangeAggregation ipv4Range = result.getAggregations().getIpv4RangeAggregation("ipv4_range1");
+        assertEquals("ipv4_range1", ipv4Range.getName());
+        assertEquals(2, ipv4Range.getRanges().size());
+
+        assertTrue(0L == ipv4Range.getRanges().get(0).getCount());
+        assertNull(ipv4Range.getRanges().get(0).getFrom());
+        assertNull(ipv4Range.getRanges().get(0).getFromAsString());
+        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getRanges().get(0).getTo());
+        assertEquals("10.0.0.25", ipv4Range.getRanges().get(0).getToAsString());
+
+        assertTrue(0L == ipv4Range.getRanges().get(1).getCount());
+        assertNull(ipv4Range.getRanges().get(1).getTo());
+        assertNull(ipv4Range.getRanges().get(1).getToAsString());
+        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getRanges().get(1).getFrom());
+        assertEquals("10.0.0.25", ipv4Range.getRanges().get(1).getFromAsString());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("ipv4_range1", Ipv4RangeAggregation.class);
+        assertTrue(aggregation instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeByType = (Ipv4RangeAggregation) aggregation;
+        assertEquals(ipv4Range, ipv4RangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("ipv4_range1", Ipv4RangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeWithMap = (Ipv4RangeAggregation) aggregations.get(0);
+        assertEquals(ipv4Range, ipv4RangeWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "ipv4_range_aggregation";
@@ -32,13 +32,13 @@ public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.23\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.1\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.1.0\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.123\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -103,13 +103,13 @@ public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.23\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.1\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.1.0\"}");
         index(INDEX, TYPE, null, "{\"address\":\"10.0.0.123\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MaxAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MaxAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class MaxAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "max_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetMaxAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"max1\" : {\n" +
+                "            \"max\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        MaxAggregation max = result.getAggregations().getMaxAggregation("max1");
+        assertEquals("max1", max.getName());
+        assertEquals(new Double(3) , max.getMax());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("max1", MaxAggregation.class);
+        assertTrue(aggregation instanceof MaxAggregation);
+        MaxAggregation maxByType = (MaxAggregation) aggregation;
+        assertEquals(max, maxByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("max1", MaxAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MaxAggregation);
+        MaxAggregation maxWithMap = (MaxAggregation) aggregations.get(0);
+        assertEquals(max, maxWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"max1\" : {\n" +
+                "            \"max\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        MaxAggregation max = result.getAggregations().getMaxAggregation("max1");
+        assertNull(max.getMax());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("max1", MaxAggregation.class);
+        assertTrue(aggregation instanceof MaxAggregation);
+        MaxAggregation maxByType = (MaxAggregation) aggregation;
+        assertEquals(max, maxByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("max1", MaxAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MaxAggregation);
+        MaxAggregation maxWithMap = (MaxAggregation) aggregations.get(0);
+        assertEquals(max, maxWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MaxAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MaxAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class MaxAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "max_aggregation";
@@ -32,11 +32,11 @@ public class MaxAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class MaxAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MinAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MinAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class MinAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "min_aggregation";
@@ -32,11 +32,11 @@ public class MinAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class MinAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MinAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MinAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class MinAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "min_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetMinAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"min1\" : {\n" +
+                "            \"min\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        MinAggregation min = result.getAggregations().getMinAggregation("min1");
+        assertEquals("min1", min.getName());
+        assertEquals(new Double(2) , min.getMin());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("min1", MinAggregation.class);
+        assertTrue(aggregation instanceof MinAggregation);
+        MinAggregation minByType = (MinAggregation) aggregation;
+        assertEquals(min, minByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("min1", MinAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MinAggregation);
+        MinAggregation minWithMap = (MinAggregation) aggregations.get(0);
+        assertEquals(min, minWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"min1\" : {\n" +
+                "            \"min\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        MinAggregation min = result.getAggregations().getMinAggregation("min1");
+        assertNull(min.getMin());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("min1", MinAggregation.class);
+        assertTrue(aggregation instanceof MinAggregation);
+        MinAggregation minByType = (MinAggregation) aggregation;
+        assertEquals(min, minByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("min1", MinAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MinAggregation);
+        MinAggregation minWithMap = (MinAggregation) aggregations.get(0);
+        assertEquals(min, minWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MissingAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MissingAggregationIntegrationTest.java
@@ -1,0 +1,130 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class MissingAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "missing_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetMissingAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        index(INDEX, TYPE, null, "{\"other\":4}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"missing1\" : {\n" +
+                "            \"missing\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        MissingAggregation missing = result.getAggregations().getMissingAggregation("missing1");
+        assertEquals("missing1", missing.getName());
+        assertTrue(1L == missing.getMissing());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("missing1", MissingAggregation.class);
+        assertTrue(aggregation instanceof MissingAggregation);
+        MissingAggregation missingByType = (MissingAggregation) aggregation;
+        assertEquals(missing, missingByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("missing1", MissingAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MissingAggregation);
+        MissingAggregation missingWithMap = (MissingAggregation) aggregations.get(0);
+        assertEquals(missing, missingWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        index(INDEX, TYPE, null, "{\"other\":4}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"missing1\" : {\n" +
+                "            \"missing\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        MissingAggregation missing = result.getAggregations().getMissingAggregation("missing1");
+        assertTrue(3L == missing.getMissing());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("missing1", MissingAggregation.class);
+        assertTrue(aggregation instanceof MissingAggregation);
+        MissingAggregation missingByType = (MissingAggregation) aggregation;
+        assertEquals(missing, missingByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("missing1", MissingAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof MissingAggregation);
+        MissingAggregation missingWithMap = (MissingAggregation) aggregations.get(0);
+        assertEquals(missing, missingWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/MissingAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/MissingAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class MissingAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "missing_aggregation";
@@ -32,12 +32,12 @@ public class MissingAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         index(INDEX, TYPE, null, "{\"other\":4}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -86,12 +86,12 @@ public class MissingAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         index(INDEX, TYPE, null, "{\"other\":4}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/PercentileRanksAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/PercentileRanksAggregationIntegrationTest.java
@@ -1,0 +1,139 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "percentile_ranks_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetPercentileRanksAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"response_millis\":{\"store\":true,\"type\":\"double\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 115}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"percent1\" : {\n" +
+                "            \"percentile_ranks\" : {\n" +
+                "                \"field\" : \"response_millis\",\n" +
+                "                \"values\" : [80.0, 100.0]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        PercentileRanksAggregation percentileRanks = result.getAggregations().getPercentileRanksAggregation("percent1");
+        assertEquals("percent1", percentileRanks.getName());
+        assertEquals(2, percentileRanks.getPercentileRanks().size());
+
+        assertEquals(new Double(52.5),percentileRanks.getPercentileRanks().get("80.0"));
+        assertEquals(new Double(62.5),percentileRanks.getPercentileRanks().get("100.0"));
+
+        Aggregation aggregation = result.getAggregations().getAggregation("percent1", PercentileRanksAggregation.class);
+        assertTrue(aggregation instanceof PercentileRanksAggregation);
+        PercentileRanksAggregation percentileRanksByType = (PercentileRanksAggregation) aggregation;
+        assertEquals(percentileRanks, percentileRanksByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("percent1", PercentileRanksAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof PercentileRanksAggregation);
+        PercentileRanksAggregation percentileRanksWithMap = (PercentileRanksAggregation) aggregations.get(0);
+        assertEquals(percentileRanks, percentileRanksWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"response_millis\":{\"store\":true,\"type\":\"double\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 115}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"percent1\" : {\n" +
+                "            \"percentile_ranks\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"values\" : [80.0, 100.0]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        PercentileRanksAggregation percentileRanks = result.getAggregations().getPercentileRanksAggregation("percent1");
+        assertTrue(percentileRanks.getPercentileRanks().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("percent1", PercentileRanksAggregation.class);
+        assertTrue(aggregation instanceof PercentileRanksAggregation);
+        PercentileRanksAggregation percentileRanksByType = (PercentileRanksAggregation) aggregation;
+        assertEquals(percentileRanks, percentileRanksByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("percent1", PercentileRanksAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof PercentileRanksAggregation);
+        PercentileRanksAggregation percentileRanksWithMap = (PercentileRanksAggregation) aggregations.get(0);
+        assertEquals(percentileRanks, percentileRanksWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/PercentileRanksAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/PercentileRanksAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "percentile_ranks_aggregation";
@@ -32,7 +32,6 @@ public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrati
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
@@ -40,6 +39,7 @@ public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrati
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 115}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -92,7 +92,6 @@ public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrati
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
@@ -100,6 +99,7 @@ public class PercentileRanksAggregationIntegrationTest extends AbstractIntegrati
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 115}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/PercentilesAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/PercentilesAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "percentiles_aggregation";
@@ -32,7 +32,6 @@ public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
@@ -40,6 +39,7 @@ public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTe
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 115}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -96,7 +96,6 @@ public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTe
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
@@ -104,6 +103,7 @@ public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTe
         index(INDEX, TYPE, null, "{\"response_millis\": 75}");
         index(INDEX, TYPE, null, "{\"response_millis\": 115}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/PercentilesAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/PercentilesAggregationIntegrationTest.java
@@ -1,0 +1,142 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class PercentilesAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "percentiles_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetPercentilesAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"response_millis\":{\"store\":true,\"type\":\"double\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 115}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"percent1\" : {\n" +
+                "            \"percentiles\" : {\n" +
+                "                \"field\" : \"response_millis\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        PercentilesAggregation percentiles = result.getAggregations().getPercentilesAggregation("percent1");
+        assertEquals("percent1", percentiles.getName());
+        assertEquals(7, percentiles.getPercentiles().size());
+
+        assertEquals(new Double(75.0),percentiles.getPercentiles().get("1.0"));
+        assertEquals(new Double(75.0),percentiles.getPercentiles().get("5.0"));
+        assertEquals(new Double(75.0),percentiles.getPercentiles().get("25.0"));
+        assertEquals(new Double(75.0),percentiles.getPercentiles().get("50.0"));
+        assertEquals(new Double(75.0),percentiles.getPercentiles().get("75.0"));
+        assertEquals(new Double(107.0),percentiles.getPercentiles().get("95.0"));
+        assertEquals(new Double(113.39999999999999),percentiles.getPercentiles().get("99.0"));
+
+        Aggregation aggregation = result.getAggregations().getAggregation("percent1", PercentilesAggregation.class);
+        assertTrue(aggregation instanceof PercentilesAggregation);
+        PercentilesAggregation percentilesByType = (PercentilesAggregation) aggregation;
+        assertEquals(percentiles, percentilesByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("percent1", PercentilesAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof PercentilesAggregation);
+        PercentilesAggregation percentilesWithMap = (PercentilesAggregation) aggregations.get(0);
+        assertEquals(percentiles, percentilesWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"response_millis\":{\"store\":true,\"type\":\"double\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 75}");
+        index(INDEX, TYPE, null, "{\"response_millis\": 115}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"percent1\" : {\n" +
+                "            \"percentiles\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        PercentilesAggregation percentiles = result.getAggregations().getPercentilesAggregation("percent1");
+        assertTrue(percentiles.getPercentiles().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("percent1", PercentilesAggregation.class);
+        assertTrue(aggregation instanceof PercentilesAggregation);
+        PercentilesAggregation percentilesByType = (PercentilesAggregation) aggregation;
+        assertEquals(percentiles, percentilesByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("percent1", PercentilesAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof PercentilesAggregation);
+        PercentilesAggregation percentilesWithMap = (PercentilesAggregation) aggregations.get(0);
+        assertEquals(percentiles, percentilesWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/RangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/RangeAggregationIntegrationTest.java
@@ -1,0 +1,167 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class RangeAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "range_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetRangeAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\": 17}");
+        index(INDEX, TYPE, null, "{\"num\":24}");
+        index(INDEX, TYPE, null, "{\"num\":42}");
+        index(INDEX, TYPE, null, "{\"num\":16}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"range1\" : {\n" +
+                "            \"range\" : {\n" +
+                "                \"field\" : \"num\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": 20},\n" +
+                "                   { \"from\": 20, \"to\": 40},\n" +
+                "                   { \"from\": 40}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        RangeAggregation range = result.getAggregations().getRangeAggregation("range1");
+        assertEquals("range1", range.getName());
+        assertEquals(3, range.getRanges().size());
+
+        assertTrue(2L == range.getRanges().get(0).getCount());
+        assertNull(range.getRanges().get(0).getFrom());
+        assertEquals(Double.valueOf("20"), range.getRanges().get(0).getTo());
+
+        assertTrue(1L == range.getRanges().get(1).getCount());
+        assertEquals(Double.valueOf("40"), range.getRanges().get(1).getTo());
+        assertEquals(Double.valueOf("20"), range.getRanges().get(1).getFrom());
+
+        assertTrue(1L == range.getRanges().get(2).getCount());
+        assertNull(range.getRanges().get(2).getTo());
+        assertEquals(Double.valueOf("40"), range.getRanges().get(2).getFrom());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("range1", RangeAggregation.class);
+        assertTrue(aggregation instanceof RangeAggregation);
+        RangeAggregation rangeByType = (RangeAggregation) aggregation;
+        assertEquals(range, rangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("range1", RangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof RangeAggregation);
+        RangeAggregation rangeWithMap = (RangeAggregation) aggregations.get(0);
+        assertEquals(range, rangeWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\": 17}");
+        index(INDEX, TYPE, null, "{\"num\":24}");
+        index(INDEX, TYPE, null, "{\"num\":42}");
+        index(INDEX, TYPE, null, "{\"num\":16}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"range1\" : {\n" +
+                "            \"range\" : {\n" +
+                "                \"field\" : \"bad_field\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"to\": 20},\n" +
+                "                   { \"from\": 20, \"to\": 40},\n" +
+                "                   { \"from\": 40}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        RangeAggregation range = result.getAggregations().getRangeAggregation("range1");
+        assertEquals("range1", range.getName());
+        assertEquals(3, range.getRanges().size());
+
+        assertTrue(0L == range.getRanges().get(0).getCount());
+        assertNull(range.getRanges().get(0).getFrom());
+        assertEquals(Double.valueOf("20"), range.getRanges().get(0).getTo());
+
+        assertTrue(0L == range.getRanges().get(1).getCount());
+        assertEquals(Double.valueOf("40"), range.getRanges().get(1).getTo());
+        assertEquals(Double.valueOf("20"), range.getRanges().get(1).getFrom());
+
+        assertTrue(0L == range.getRanges().get(2).getCount());
+        assertNull(range.getRanges().get(2).getTo());
+        assertEquals(Double.valueOf("40"), range.getRanges().get(2).getFrom());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("range1", RangeAggregation.class);
+        assertTrue(aggregation instanceof RangeAggregation);
+        RangeAggregation rangeByType = (RangeAggregation) aggregation;
+        assertEquals(range, rangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("range1", RangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof RangeAggregation);
+        RangeAggregation rangeWithMap = (RangeAggregation) aggregations.get(0);
+        assertEquals(range, rangeWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/RangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/RangeAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class RangeAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "range_aggregation";
@@ -32,13 +32,13 @@ public class RangeAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\": 17}");
         index(INDEX, TYPE, null, "{\"num\":24}");
         index(INDEX, TYPE, null, "{\"num\":42}");
         index(INDEX, TYPE, null, "{\"num\":16}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -104,13 +104,13 @@ public class RangeAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\": 17}");
         index(INDEX, TYPE, null, "{\"num\":24}");
         index(INDEX, TYPE, null, "{\"num\":42}");
         index(INDEX, TYPE, null, "{\"num\":16}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregationIntegrationTest.java
@@ -1,0 +1,136 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class ScriptedMetricAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "scripted_metric_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetScriptedMetricAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"amount\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"amount\":2}");
+        index(INDEX, TYPE, null, "{\"amount\":3}");
+        index(INDEX, TYPE, null, "{\"amount\":-1}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"profit\" : {\n" +
+                "            \"scripted_metric\" : {\n" +
+                "                \"init_script\" : \"_agg['transactions'] = []\",\n" +
+                "                \"map_script\" : \"_agg.transactions.add(doc['amount'].value)\",\n" +
+                "                \"combine_script\" : \"profit = 0; for (t in _agg.transactions) { profit += t }; return profit\",\n" +
+                "                \"reduce_script\" : \"profit = 0; for (a in _aggs) { profit += a }; return profit\"\n"+
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        ScriptedMetricAggregation scriptedMetric = result.getAggregations().getScriptedMetricAggregation("profit");
+        assertEquals("profit", scriptedMetric.getName());
+        assertEquals(new Double(4) , scriptedMetric.getScriptedMetric());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("profit", ScriptedMetricAggregation.class);
+        assertTrue(aggregation instanceof ScriptedMetricAggregation);
+        ScriptedMetricAggregation scriptedMetricByType = (ScriptedMetricAggregation) aggregation;
+        assertEquals(scriptedMetric, scriptedMetricByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("profit", ScriptedMetricAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ScriptedMetricAggregation);
+        ScriptedMetricAggregation scriptedMetricWithMap = (ScriptedMetricAggregation) aggregations.get(0);
+        assertEquals(scriptedMetric, scriptedMetricWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"amount\":2}");
+        index(INDEX, TYPE, null, "{\"amount\":3}");
+        index(INDEX, TYPE, null, "{\"amount\":-1}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"profit\" : {\n" +
+                "            \"scripted_metric\" : {\n" +
+                "                \"init_script\" : \"_agg['transactions'] = []\",\n" +
+                "                \"map_script\" : \"_agg.transactions.add(doc['bad_field'].value)\",\n" +
+                "                \"combine_script\" : \"profit = 0; for (t in _agg.transactions) { profit += t }; return profit\",\n" +
+                "                \"reduce_script\" : \"profit = 0; for (a in _aggs) { profit += a }; return profit\"\n"+
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        ScriptedMetricAggregation scriptedMetric = result.getAggregations().getScriptedMetricAggregation("profit");
+        assertEquals(new Double(0), scriptedMetric.getScriptedMetric());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("profit", ScriptedMetricAggregation.class);
+        assertTrue(aggregation instanceof ScriptedMetricAggregation);
+        ScriptedMetricAggregation scriptedMetricByType = (ScriptedMetricAggregation) aggregation;
+        assertEquals(scriptedMetric, scriptedMetricByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("profit", ScriptedMetricAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ScriptedMetricAggregation);
+        ScriptedMetricAggregation scriptedMetricWithMap = (ScriptedMetricAggregation) aggregations.get(0);
+        assertEquals(scriptedMetric, scriptedMetricWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "significant_terms_aggregation";
@@ -24,7 +24,7 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
 
     @Test
     public void testGetSignificantTermsAggregation()
-            throws IOException {
+            throws Exception {
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
@@ -33,11 +33,11 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
+        waitForConcreteMappingsOnAll(INDEX, TYPE, "gender", "favorite_movie");
 
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
-        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"ToyStory\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Toy Story\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Harry Potter\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Twilight\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
@@ -46,6 +46,7 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"The Notebook\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Titanic\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -91,7 +92,7 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
 
     @Test
     public void testBadAggregationQueryResult()
-            throws IOException {
+            throws Exception {
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
@@ -100,11 +101,11 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
+        waitForConcreteMappingsOnAll(INDEX, TYPE, "gender", "favorite_movie");
 
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
-        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"ToyStory\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Toy Story\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Harry Potter\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Twilight\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
@@ -113,6 +114,7 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"The Notebook\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Titanic\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
@@ -1,0 +1,152 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "significant_terms_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetSignificantTermsAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"},"+
+                         "\"favorite_movie\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"ToyStory\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Harry Potter\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"The Notebook\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Titanic\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"terms\" : {\"gender\": [\"female\"]}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"significant_terms1\" : {\n" +
+                "            \"significant_terms\" : {\n" +
+                "                \"field\" : \"favorite_movie\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        SignificantTermsAggregation significantTerms = result.getAggregations().getSignificantTermsAggregation("significant_terms1");
+        assertEquals("significant_terms1", significantTerms.getName());
+        assertTrue(5L == significantTerms.getTotalCount());
+        assertEquals(1, significantTerms.getSignificantTerms().size());
+        assertEquals("twilight", significantTerms.getSignificantTerms().get(0).getKey());
+        assertTrue(3L == significantTerms.getSignificantTerms().get(0).getCount());
+        assertEquals(new Double(0.2999999999999999), significantTerms.getSignificantTerms().get(0).getScore());
+        assertTrue(4L == significantTerms.getSignificantTerms().get(0).getBackgroundCount());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("significant_terms1", SignificantTermsAggregation.class);
+        assertTrue(aggregation instanceof SignificantTermsAggregation);
+        SignificantTermsAggregation significantTermsByType = (SignificantTermsAggregation) aggregation;
+        assertEquals(significantTerms, significantTermsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("significant_terms1", SignificantTermsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof SignificantTermsAggregation);
+        SignificantTermsAggregation significantTermsWithMap = (SignificantTermsAggregation) aggregations.get(0);
+        assertEquals(significantTermsWithMap, significantTermsByType);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"},"+
+                                "\"favorite_movie\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"300\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"ToyStory\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Harry Potter\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Twilight\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"The Notebook\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\", \"favorite_movie\": \"Titanic\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"terms\" : {\"gender\": [\"female\"]}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"significant_terms1\" : {\n" +
+                "            \"significant_terms\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        SignificantTermsAggregation significantTerms = result.getAggregations().getSignificantTermsAggregation("significant_terms1");
+        assertNull(significantTerms.getTotalCount());
+        assertTrue(significantTerms.getSignificantTerms().isEmpty());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("significant_terms1", SignificantTermsAggregation.class);
+        assertTrue(aggregation instanceof SignificantTermsAggregation);
+        SignificantTermsAggregation significantTermsByType = (SignificantTermsAggregation) aggregation;
+        assertEquals(significantTerms, significantTermsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("significant_terms1", SignificantTermsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof SignificantTermsAggregation);
+        SignificantTermsAggregation significantTermsWithMap = (SignificantTermsAggregation) aggregations.get(0);
+        assertEquals(significantTermsWithMap, significantTermsByType);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/StatsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/StatsAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class StatsAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "stats_aggregation";
@@ -32,11 +32,11 @@ public class StatsAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -89,11 +89,11 @@ public class StatsAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/StatsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/StatsAggregationIntegrationTest.java
@@ -1,0 +1,138 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class StatsAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "stats_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetStatsAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"stats1\" : {\n" +
+                "            \"stats\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        StatsAggregation stats = result.getAggregations().getStatsAggregation("stats1");
+        assertEquals("stats1", stats.getName());
+        assertEquals(new Double(2.5) , stats.getAvg());
+        assertTrue(2L == stats.getCount());
+        assertEquals(new Double(3) , stats.getMax());
+        assertEquals(new Double(2) , stats.getMin());
+        assertEquals(new Double(5) , stats.getSum());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("stats1", StatsAggregation.class);
+        assertTrue(aggregation instanceof StatsAggregation);
+        StatsAggregation statsByType = (StatsAggregation) aggregation;
+        assertEquals(stats, statsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("stats1", StatsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof StatsAggregation);
+        StatsAggregation statsWithMap = (StatsAggregation) aggregations.get(0);
+        assertEquals(stats, statsWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"stats1\" : {\n" +
+                "            \"stats\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        StatsAggregation stats = result.getAggregations().getStatsAggregation("stats1");
+        assertEquals("stats1", stats.getName());
+        assertNull(stats.getAvg());
+        assertTrue(0L == stats.getCount());
+        assertNull(stats.getMax());
+        assertNull(stats.getMin());
+        assertNull(stats.getSum());
+
+
+        Aggregation aggregation = result.getAggregations().getAggregation("stats1", StatsAggregation.class);
+        assertTrue(aggregation instanceof StatsAggregation);
+        StatsAggregation statsByType = (StatsAggregation) aggregation;
+        assertEquals(stats, statsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("stats1", StatsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof StatsAggregation);
+        StatsAggregation statsWithMap = (StatsAggregation) aggregations.get(0);
+        assertEquals(stats, statsWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/SumAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/SumAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class SumAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "sum_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetSumAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"sum1\" : {\n" +
+                "            \"sum\" : {\n" +
+                "                \"field\" : \"num\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        SumAggregation sum = result.getAggregations().getSumAggregation("sum1");
+        assertEquals("sum1", sum.getName());
+        assertEquals(new Double(5) , sum.getSum());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("sum1", SumAggregation.class);
+        assertTrue(aggregation instanceof SumAggregation);
+        SumAggregation sumByType = (SumAggregation) aggregation;
+        assertEquals(sum, sumByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("sum1", SumAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof SumAggregation);
+        SumAggregation sumWithMap = (SumAggregation) aggregations.get(0);
+        assertEquals(sum, sumWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"sum1\" : {\n" +
+                "            \"sum\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        SumAggregation sum = result.getAggregations().getSumAggregation("sum1");
+        assertEquals(new Double(0), sum.getSum());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("sum1", SumAggregation.class);
+        assertTrue(aggregation instanceof SumAggregation);
+        SumAggregation sumByType = (SumAggregation) aggregation;
+        assertEquals(sum, sumByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("sum1", SumAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof SumAggregation);
+        SumAggregation sumWithMap = (SumAggregation) aggregations.get(0);
+        assertEquals(sum, sumWithMap);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/SumAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/SumAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class SumAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "sum_aggregation";
@@ -32,11 +32,11 @@ public class SumAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class SumAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
@@ -1,0 +1,138 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class TermsAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "terms_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetTermsAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"terms1\" : {\n" +
+                "            \"terms\" : {\n" +
+                "                \"field\" : \"gender\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        TermsAggregation terms = result.getAggregations().getTermsAggregation("terms1");
+        assertEquals("terms1", terms.getName());
+        assertTrue(0L == terms.getDocCountErrorUpperBound());
+        assertTrue(0L == terms.getSumOtherDocCount());
+        assertEquals(2, terms.getBuckets().size());
+        assertTrue(2L == terms.getBuckets().get(0).getCount());
+        assertEquals("male", terms.getBuckets().get(0).getName());
+        assertTrue(1L == terms.getBuckets().get(1).getCount());
+        assertEquals("female", terms.getBuckets().get(1).getName());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("terms1", TermsAggregation.class);
+        assertTrue(aggregation instanceof TermsAggregation);
+        TermsAggregation termsByType = (TermsAggregation) aggregation;
+        assertEquals(terms, termsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("terms1", TermsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof TermsAggregation);
+        TermsAggregation termsWithMap = (TermsAggregation) aggregations.get(0);
+        assertEquals(termsWithMap, termsByType);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
+        index(INDEX, TYPE, null, "{\"gender\":\"female\"}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"terms1\" : {\n" +
+                "            \"terms\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        TermsAggregation terms = result.getAggregations().getTermsAggregation("terms1");
+        assertEquals(0, terms.getBuckets().size());
+        assertTrue(0L == terms.getDocCountErrorUpperBound());
+        assertTrue(0L == terms.getSumOtherDocCount());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("terms1", TermsAggregation.class);
+        assertTrue(aggregation instanceof TermsAggregation);
+        TermsAggregation termsByType = (TermsAggregation) aggregation;
+        assertEquals(terms, termsByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("terms1", TermsAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof TermsAggregation);
+        TermsAggregation termsWithMap = (TermsAggregation) aggregations.get(0);
+        assertEquals(termsWithMap, termsByType);
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class TermsAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "terms_aggregation";
@@ -32,12 +32,12 @@ public class TermsAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -92,12 +92,12 @@ public class TermsAggregationIntegrationTest extends AbstractIntegrationTest {
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"male\"}");
         index(INDEX, TYPE, null, "{\"gender\":\"female\"}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ValueCountAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ValueCountAggregationIntegrationTest.java
@@ -16,7 +16,7 @@ import java.util.Map;
 /**
  * @author cfstout
  */
-@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.TEST, numDataNodes = 1)
 public class ValueCountAggregationIntegrationTest extends AbstractIntegrationTest {
 
     private final String INDEX = "value_count_aggregation";
@@ -32,11 +32,11 @@ public class ValueCountAggregationIntegrationTest extends AbstractIntegrationTes
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +
@@ -85,11 +85,11 @@ public class ValueCountAggregationIntegrationTest extends AbstractIntegrationTes
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
-        ensureSearchable(INDEX);
 
         index(INDEX, TYPE, null, "{\"num\":2}");
         index(INDEX, TYPE, null, "{\"num\":3}");
         refresh();
+        ensureSearchable(INDEX);
 
         String query = "{\n" +
                 "    \"query\" : {\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ValueCountAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ValueCountAggregationIntegrationTest.java
@@ -1,0 +1,128 @@
+package io.searchbox.core.search.aggregation;
+
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Search;
+import io.searchbox.core.SearchResult;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingRequest;
+import org.elasticsearch.action.admin.indices.mapping.put.PutMappingResponse;
+import org.elasticsearch.test.ElasticsearchIntegrationTest;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @author cfstout
+ */
+@ElasticsearchIntegrationTest.ClusterScope (scope = ElasticsearchIntegrationTest.Scope.SUITE, numDataNodes = 1)
+public class ValueCountAggregationIntegrationTest extends AbstractIntegrationTest {
+
+    private final String INDEX = "value_count_aggregation";
+    private final String TYPE = "document";
+
+    @Test
+    public void testGetValueCountAggregation()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"value_count1\" : {\n" +
+                "            \"value_count\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        ValueCountAggregation valueCount = result.getAggregations().getValueCountAggregation("value_count1");
+        assertEquals("value_count1", valueCount.getName());
+        assertTrue(0L == valueCount.getValueCount());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("value_count1", ValueCountAggregation.class);
+        assertTrue(aggregation instanceof ValueCountAggregation);
+        ValueCountAggregation valueCountByType = (ValueCountAggregation) aggregation;
+        assertEquals(valueCount, valueCountByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("value_count1", ValueCountAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ValueCountAggregation);
+        ValueCountAggregation valueCountWithMap = (ValueCountAggregation) aggregations.get(0);
+        assertEquals(valueCount, valueCountWithMap);
+    }
+
+    @Test
+    public void testBadAggregationQueryResult()
+            throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"num\":{\"store\":true,\"type\":\"integer\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+        ensureSearchable(INDEX);
+
+        index(INDEX, TYPE, null, "{\"num\":2}");
+        index(INDEX, TYPE, null, "{\"num\":3}");
+        refresh();
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"value_count1\" : {\n" +
+                "            \"value_count\" : {\n" +
+                "                \"field\" : \"bad_field\"\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        ValueCountAggregation valueCount = result.getAggregations().getValueCountAggregation("value_count1");
+        assertTrue(0L == valueCount.getValueCount());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("value_count1", ValueCountAggregation.class);
+        assertTrue(aggregation instanceof ValueCountAggregation);
+        ValueCountAggregation valueCountByType = (ValueCountAggregation) aggregation;
+        assertEquals(valueCount, valueCountByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("value_count1", ValueCountAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof ValueCountAggregation);
+        ValueCountAggregation valueCountWithMap = (ValueCountAggregation) aggregations.get(0);
+        assertEquals(valueCount, valueCountWithMap);
+    }
+}


### PR DESCRIPTION
I have create three ways to get aggregation data from a search response.

1) End user can call `get<X>Aggregation(String aggName)` where X is the type of
aggregation expected and agg name is the name of the aggregation.

2) User can call `getAggregation(String aggName, Class<T> aggType)` where
aggName is the name of the aggregation and aggType is the type expected for
that particular aggregation.

3) User can call `getAggregations(Map<String, Class<T>> nameToTypeMap)` which
provides a map of names to expected types for this level of aggregation.
A list of aggregations of the given types will be returned as a result.

In order to handle nested aggregations, the root `Aggregation` class contains all three methods.
The `getAggregations()` call in `SearchResult` returns the root level aggregation.
Thus to get an average aggregation named 'avg1' the end user would make a call like:
`searchResult.getAggregations().getAvgAggregation('avg1')` which would then have the
`getAvg` method available. Nested aggregations could then be achieved by nesting these calls to
the aggregations returned at each call:
`searchResult.getAggregations.getTermsAggregation('term1').getAvgAggregation('avg1')`

Tests were added for each of these Aggregation objects with the objective of testing
all methods of a particular aggregation object in the case where a user provides
a proper name, and in the case where they provide a bad name by which to get the
aggregation.

Finally, many of these methods have the potential to create null values, as a bad
name will lead to no data being returned. I have commented in JavaDoc style these
methods with the potential to return null so that end users will be aware of the
possibility.