### PR TITLE
Deserialization process should not swallow exceptions

### DIFF
--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -86,7 +86,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
         return result;
     }
 
-    protected static JsonObject convertJsonStringToMapObject(String jsonTxt) {
+    protected JsonObject convertJsonStringToMapObject(String jsonTxt) {
         if (jsonTxt != null && !jsonTxt.trim().isEmpty()) {
                 return new JsonParser().parse(jsonTxt).getAsJsonObject();
         }

--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -88,11 +88,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
 
     protected static JsonObject convertJsonStringToMapObject(String jsonTxt) {
         if (jsonTxt != null && !jsonTxt.trim().isEmpty()) {
-            try {
                 return new JsonParser().parse(jsonTxt).getAsJsonObject();
-            } catch (Exception e) {
-                log.error("An exception occurred while converting json string to map object");
-            }
         }
         return new JsonObject();
     }

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesHotThreads.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesHotThreads.java
@@ -1,5 +1,6 @@
 package io.searchbox.cluster;
 
+import com.google.gson.JsonObject;
 import io.searchbox.action.AbstractMultiINodeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
 
@@ -24,6 +25,11 @@ public class NodesHotThreads extends GenericResultAbstractAction {
                 .append(nodes)
                 .append("/hot_threads");
         return sb.toString();
+    }
+
+    @Override
+    protected JsonObject convertJsonStringToMapObject(String jsonTxt) {
+        return new JsonObject();
     }
 
     @Override

--- a/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
+++ b/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
@@ -2,6 +2,7 @@ package io.searchbox.action;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonSyntaxException;
 import io.searchbox.annotations.JestId;
 import io.searchbox.client.JestResult;
 import io.searchbox.core.Delete;
@@ -9,7 +10,9 @@ import io.searchbox.core.Get;
 import io.searchbox.core.Index;
 import io.searchbox.core.Update;
 import io.searchbox.indices.Flush;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 import static org.junit.Assert.*;
 
@@ -17,6 +20,9 @@ import static org.junit.Assert.*;
  * @author Dogukan Sonmez
  */
 public class AbstractActionTest {
+
+    @Rule
+    public ExpectedException exception = ExpectedException.none();
 
     @Test
     public void buildRestUrlWithValidParameters() {
@@ -177,6 +183,12 @@ public class AbstractActionTest {
     public void convertNullJsonStringToMapObject() {
         JsonObject jsonMap = AbstractAction.convertJsonStringToMapObject(null);
         assertNotNull(jsonMap);
+    }
+
+    @Test
+    public void propagateExceptionWhenTheResponseIsNotJson() {
+        exception.expect(JsonSyntaxException.class);
+        AbstractAction.convertJsonStringToMapObject("401 Unauthorized");
     }
 
 

--- a/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
+++ b/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
@@ -21,9 +21,6 @@ import static org.junit.Assert.*;
  */
 public class AbstractActionTest {
 
-    @Rule
-    public ExpectedException exception = ExpectedException.none();
-
     @Test
     public void buildRestUrlWithValidParameters() {
         String expected = "twitter/tweet/1";
@@ -164,7 +161,7 @@ public class AbstractActionTest {
                 "    \"_type\" : \"tweet\",\n" +
                 "    \"_id\" : \"1\"\n" +
                 "}";
-        JsonObject jsonMap = AbstractAction.convertJsonStringToMapObject(json);
+        JsonObject jsonMap = new DummyAction.Builder().build().convertJsonStringToMapObject(json);
         assertNotNull(jsonMap);
         assertEquals(4, jsonMap.entrySet().size());
         assertEquals(true, jsonMap.get("ok").getAsBoolean());
@@ -175,20 +172,19 @@ public class AbstractActionTest {
 
     @Test
     public void convertEmptyJsonStringToMapObject() {
-        JsonObject jsonMap = AbstractAction.convertJsonStringToMapObject("");
+        JsonObject jsonMap = new DummyAction.Builder().build().convertJsonStringToMapObject("");
         assertNotNull(jsonMap);
     }
 
     @Test
     public void convertNullJsonStringToMapObject() {
-        JsonObject jsonMap = AbstractAction.convertJsonStringToMapObject(null);
+        JsonObject jsonMap = new DummyAction.Builder().build().convertJsonStringToMapObject(null);
         assertNotNull(jsonMap);
     }
 
-    @Test
+    @Test(expected = JsonSyntaxException.class)
     public void propagateExceptionWhenTheResponseIsNotJson() {
-        exception.expect(JsonSyntaxException.class);
-        AbstractAction.convertJsonStringToMapObject("401 Unauthorized");
+        new DummyAction.Builder().build().convertJsonStringToMapObject("401 Unauthorized");
     }
 
 

--- a/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
@@ -73,7 +73,10 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void searchWithQueryBuilder() throws IOException {
-        Index index = new Index.Builder("{\"user\":\"kimchy\"}").setParameter(Parameters.REFRESH, true).build();
+        Index index = new Index.Builder("{\"user\":\"kimchy\"}")
+                .index("twitter")
+                .type("tweet")
+                .setParameter(Parameters.REFRESH, true).build();
         client.execute(index);
         SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
         searchSourceBuilder.query(QueryBuilders.matchQuery("user", "kimchy"));


### PR DESCRIPTION
Hi,

We've found an interesting issue in one of our clusters today.

1. We have a proxy in front of elasticsearch client nodes. Among other things this proxy does a http authentication. 
2. A java app uses jest client to do a request to the proxy
3. We had a configuration error and proxy was responding with 401 unathorized, but we missed it since no exception was thrown. We only noticed later when we were investigatin an issue this lead to,

In short - I think we should not swallow exceptions when parsing response body. I'm not sure if my way (removing the try-catch) is the best, but it was good enough for our usecase.

Please suggest if this makes sense or do you prefer some other solution.