### PR TITLE
Update NodeChecker.java

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -53,7 +53,7 @@ public class NodeChecker extends AbstractScheduledService {
                     JsonElement addressElement = host.get("http_address");
                     if (null != addressElement) {
                         String http_address = addressElement.getAsString();
-                        String cleanHttpAddress = "http://" + http_address.substring(6, http_address.length() - 1);
+                        String cleanHttpAddress = "http://" + http_address.substring(5, http_address.length() - 1);
                         httpHosts.add(cleanHttpAddress);
                     }
                 }


### PR DESCRIPTION
Two issues:
* incorrect cleanHttpAddress resulting from incorrect substring (easy fix suggested, see below for a little bit more details)
* hard-coded "http://" protocol forces the client to go HTTP, while it should be possible to choose the protocol I think via a proper ClientConfig setting.
 
Testing the node checker, I found that the response has this format
```
{
   "cluster_name": "cluster",
   "nodes": {
      "node": {
         "name": "instance-01",
         "transport_address": "inet[<host>/<ip>:<port>]",
         "host": "<host>",
         "ip": "<ip>",
         "version": "1.4.4",
         "build": "c88f77f",
         "http_address": "inet[<domain>/<ip>:<port>]",
         ...
      },
      ...
  }
}
```
hence the changed substring incorrectly strips the first char in <host> causing any further action not to failed because of an unknown host.