### PR TITLE
Replace StringBuilder with String concatenation, as suggested by IntelliJ

### DIFF
--- a/jest-common/src/main/java/io/searchbox/cluster/GetSettings.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/GetSettings.java
@@ -16,9 +16,7 @@ public class GetSettings extends GenericResultAbstractAction {
     }
 
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_cluster/settings");
-        return sb.toString();
+        return super.buildURI() + "/_cluster/settings";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/Health.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/Health.java
@@ -16,9 +16,7 @@ public class Health extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_cluster/health/");
-        return sb.toString();
+        return super.buildURI() + "/_cluster/health/";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesHotThreads.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesHotThreads.java
@@ -20,11 +20,9 @@ public class NodesHotThreads extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_nodes/")
-                .append(nodes)
-                .append("/hot_threads");
-        return sb.toString();
+        return super.buildURI() + "/_nodes/" +
+                nodes +
+                "/hot_threads";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesInfo.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesInfo.java
@@ -16,9 +16,7 @@ public class NodesInfo extends GenericResultAbstractAction {
     }
 
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_nodes").append("/").append(nodes);
-        return sb.toString();
+        return super.buildURI() + "/_nodes/" + nodes;
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesShutdown.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesShutdown.java
@@ -17,11 +17,9 @@ public class NodesShutdown extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_nodes/")
-                .append(nodes)
-                .append("/_shutdown");
-        return sb.toString();
+        return super.buildURI() + "/_nodes/" +
+                nodes +
+                "/_shutdown";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesStats.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesStats.java
@@ -17,11 +17,9 @@ public class NodesStats extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_nodes/")
-                .append(nodes)
-                .append("/stats");
-        return sb.toString();
+        return super.buildURI() + "/_nodes/" +
+                nodes +
+                "/stats";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/State.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/State.java
@@ -16,9 +16,7 @@ public class State extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_cluster/state");
-        return sb.toString();
+        return super.buildURI() + "/_cluster/state";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
@@ -25,9 +25,7 @@ public class UpdateSettings extends GenericResultAbstractAction {
     }
 
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_cluster/settings");
-        return sb.toString();
+        return super.buildURI() + "/_cluster/settings";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Bulk.java
+++ b/jest-common/src/main/java/io/searchbox/core/Bulk.java
@@ -117,9 +117,7 @@ public class Bulk extends AbstractAction<BulkResult> {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_bulk");
-        return sb.toString();
+        return super.buildURI() + "/_bulk";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Count.java
+++ b/jest-common/src/main/java/io/searchbox/core/Count.java
@@ -21,9 +21,7 @@ public class Count extends AbstractAction<CountResult> {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_count");
-        return sb.toString();
+        return super.buildURI() + "/_count";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
+++ b/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
@@ -20,9 +20,7 @@ public class DeleteByQuery extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_query");
-        return sb.toString();
+        return super.buildURI() + "/_query";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Explain.java
+++ b/jest-common/src/main/java/io/searchbox/core/Explain.java
@@ -23,9 +23,7 @@ public class Explain extends GenericResultAbstractDocumentTargetedAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_explain");
-        return sb.toString();
+        return super.buildURI() + "/_explain";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/MoreLikeThis.java
+++ b/jest-common/src/main/java/io/searchbox/core/MoreLikeThis.java
@@ -19,9 +19,7 @@ public class MoreLikeThis extends GenericResultAbstractDocumentTargetedAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_mlt");
-        return sb.toString();
+        return super.buildURI() + "/_mlt";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/MultiGet.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiGet.java
@@ -46,9 +46,7 @@ public class MultiGet extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_mget");
-        return sb.toString();
+        return super.buildURI() + "/_mget";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
@@ -55,9 +55,7 @@ public class MultiSearch extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_msearch");
-        return sb.toString();
+        return super.buildURI() + "/_msearch";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Percolate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Percolate.java
@@ -28,9 +28,7 @@ public class Percolate extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_percolate");
-        return sb.toString();
+        return super.buildURI() + "/_percolate";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Search.java
+++ b/jest-common/src/main/java/io/searchbox/core/Search.java
@@ -43,9 +43,7 @@ public class Search extends AbstractAction<SearchResult> {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_search");
-        return sb.toString();
+        return super.buildURI() + "/_search";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
@@ -30,9 +30,7 @@ public class SearchScroll extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_search/scroll");
-        return sb.toString();
+        return super.buildURI() + "/_search/scroll";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/SearchShards.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchShards.java
@@ -18,9 +18,7 @@ public class SearchShards extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_search_shards");
-        return sb.toString();
+        return super.buildURI() + "/_search_shards";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Suggest.java
+++ b/jest-common/src/main/java/io/searchbox/core/Suggest.java
@@ -35,9 +35,7 @@ public class Suggest extends AbstractAction<SuggestResult> {
 
     @Override
     protected String buildURI() {
-        final StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_suggest");
-        return sb.toString();
+        return super.buildURI() + "/_suggest";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Update.java
+++ b/jest-common/src/main/java/io/searchbox/core/Update.java
@@ -26,9 +26,7 @@ public class Update extends GenericResultAbstractDocumentTargetedAction implemen
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_update");
-        return sb.toString();
+        return super.buildURI() + "/_update";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/Validate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Validate.java
@@ -21,9 +21,7 @@ public class Validate extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder(super.buildURI());
-        sb.append("/_validate/query");
-        return sb.toString();
+        return super.buildURI() + "/_validate/query";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/Analyze.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Analyze.java
@@ -23,9 +23,7 @@ public class Analyze extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_analyze");
-        return sb.toString();
+        return super.buildURI() + "/_analyze";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/ClearCache.java
+++ b/jest-common/src/main/java/io/searchbox/indices/ClearCache.java
@@ -16,9 +16,7 @@ public class ClearCache extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_cache/clear");
-        return sb.toString();
+        return super.buildURI() + "/_cache/clear";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/CloseIndex.java
+++ b/jest-common/src/main/java/io/searchbox/indices/CloseIndex.java
@@ -16,9 +16,7 @@ public class CloseIndex extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_close");
-        return sb.toString();
+        return super.buildURI() + "/_close";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/Flush.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Flush.java
@@ -16,9 +16,7 @@ public class Flush extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_flush");
-        return sb.toString();
+        return super.buildURI() + "/_flush";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/OpenIndex.java
+++ b/jest-common/src/main/java/io/searchbox/indices/OpenIndex.java
@@ -15,9 +15,7 @@ public class OpenIndex extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_open");
-        return sb.toString();
+        return super.buildURI() + "/_open";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/Optimize.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Optimize.java
@@ -21,9 +21,7 @@ public class Optimize extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_optimize");
-        return sb.toString();
+        return super.buildURI() + "/_optimize";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<Optimize, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/Refresh.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Refresh.java
@@ -21,9 +21,7 @@ public class Refresh extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_refresh");
-        return sb.toString();
+        return super.buildURI() + "/_refresh";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<Refresh, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/Stats.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Stats.java
@@ -25,9 +25,7 @@ public class Stats extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_stats");
-        return sb.toString();
+        return super.buildURI() + "/_stats";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<Stats, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/Status.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Status.java
@@ -22,9 +22,7 @@ public class Status extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_status");
-        return sb.toString();
+        return super.buildURI() + "/_status";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<Status, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/aliases/GetAliases.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/GetAliases.java
@@ -20,9 +20,7 @@ public class GetAliases extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_aliases");
-        return sb.toString();
+        return super.buildURI() + "/_aliases";
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<GetAliases, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/aliases/ModifyAliases.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/ModifyAliases.java
@@ -28,9 +28,7 @@ public class ModifyAliases extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_aliases");
-        return sb.toString();
+        return super.buildURI() + "/_aliases";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/mapping/DeleteMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/mapping/DeleteMapping.java
@@ -19,9 +19,7 @@ public class DeleteMapping extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_mapping");
-        return sb.toString();
+        return super.buildURI() + "/_mapping";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/mapping/GetMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/mapping/GetMapping.java
@@ -21,9 +21,7 @@ public class GetMapping extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_mapping");
-        return sb.toString();
+        return super.buildURI() + "/_mapping";
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<GetMapping, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
@@ -21,9 +21,7 @@ public class PutMapping extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_mapping");
-        return sb.toString();
+        return super.buildURI() + "/_mapping";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/indices/settings/IndicesSettingsAbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/indices/settings/IndicesSettingsAbstractAction.java
@@ -14,9 +14,7 @@ public abstract class IndicesSettingsAbstractAction extends GenericResultAbstrac
 
     @Override
     protected String buildURI() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(super.buildURI()).append("/_settings");
-        return sb.toString();
+        return super.buildURI() + "/_settings";
     }
 
 }


### PR DESCRIPTION
Hi,

I replaced all usages of StringBuilder in child classes of Action by String concatenation.
This is a standard inspection by IntelliJ IDEA and simply makes the code shorter.
Therefore I simply applied the IntelliJ quick fix.

IntelliJ code inspection, cite:
"Reports any variables declared as or uses of java.lang.StringBuffer and java.lang.StringBuilder which can be replaced with a single java.lang.String concatenation. Using a String concatenation makes the code shorter and simpler. This inspection only reports when the resulting concatenation is at least as efficient or more efficient than the original StringBuffer or StringBuilder use."