### PR TITLE
Remove slf4j and fix JavaDoc errors

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -83,18 +83,6 @@
             <artifactId>elasticsearch</artifactId>
         </dependency>
 
-        <!--Logging -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>

--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -1,27 +1,32 @@
 package io.searchbox.action;
 
-import com.google.common.collect.HashMultimap;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.net.URLEncoder;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+
 import io.searchbox.annotations.JestId;
 import io.searchbox.client.JestResult;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Field;
-import java.net.URLEncoder;
-import java.util.*;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 
 /**
  * @author Dogukan Sonmez
@@ -31,7 +36,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
 
     public static String CHARSET = "utf-8";
 
-    protected final static Logger log = LoggerFactory.getLogger(AbstractAction.class);
+    protected final static Logger log = Logger.getLogger(AbstractAction.class.getName());
     protected String indexName;
     protected String typeName;
     protected String nodes;
@@ -72,7 +77,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
 
         if (isHttpSuccessful(statusCode)) {
             result.setSucceeded(true);
-            log.debug("Request and operation succeeded");
+            log.finest("Request and operation succeeded");
         } else {
             result.setSucceeded(false);
             // provide the generic HTTP status code error, if one hasn't already come in via the JSON response...
@@ -82,7 +87,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
             if (result.getErrorMessage() == null) {
                 result.setErrorMessage(statusCode + " " + (reasonPhrase == null ? "null" : reasonPhrase));
             }
-            log.debug("Response is failed");
+            log.finest("Response is failed");
         }
         return result;
     }
@@ -108,7 +113,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
                     Object name = field.get(source);
                     return name == null ? null : name.toString();
                 } catch (IllegalAccessException e) {
-                    log.error("Unhandled exception occurred while getting annotated id from source", e);
+                    log.log(Level.FINEST, "Unhandled exception occurred while getting annotated id from source", e);
                 }
             }
         }
@@ -137,7 +142,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
             } catch (UnsupportedEncodingException e) {
                 // unless CHARSET is overridden with a wrong value in a subclass,
                 // this exception won't be thrown.
-                log.error("Error occurred while adding parameters to uri.", e);
+                log.log(Level.SEVERE, "Error occurred while adding parameters to uri.", e);
             }
         }
         return finalUri;
@@ -181,7 +186,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
         } catch (UnsupportedEncodingException e) {
             // unless CHARSET is overridden with a wrong value in a subclass,
             // this exception won't be thrown.
-            log.error("Error occurred while adding index/type to uri", e);
+            log.log(Level.SEVERE, "Error occurred while adding index/type to uri", e);
         }
 
         return sb.toString();

--- a/jest-common/src/main/java/io/searchbox/action/AbstractDocumentTargetedAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractDocumentTargetedAction.java
@@ -5,6 +5,7 @@ import org.apache.commons.lang3.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
+import java.util.logging.Level;
 
 /**
  * @author cihat keser
@@ -43,7 +44,7 @@ public abstract class AbstractDocumentTargetedAction<T extends JestResult> exten
             try {
                 sb.append("/").append(URLEncoder.encode(id, CHARSET));
             } catch (UnsupportedEncodingException e) {
-                log.error("Error occurred while adding document id to uri.", e);
+                log.log(Level.SEVERE, "Error occurred while adding document id to uri.", e);
             }
         }
         return sb.toString();

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiINodeActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiINodeActionBuilder.java
@@ -13,23 +13,23 @@ public abstract class AbstractMultiINodeActionBuilder<T extends Action, K> exten
     private Collection<String> nodes = new LinkedList<String>();
 
     /**
-     * Most cluster level APIs allow to specify which nodes to execute on (for example, getting the node stats for a node).
+     * <p>Most cluster level APIs allow to specify which nodes to execute on (for example, getting the node stats for a node).
      * Nodes can be identified in the APIs either using their internal node id, the node name, address, custom attributes,
      * or just the _local node receiving the request. For example, here are some sample values for node:
-     * <p/>
+     * </p>
      * <pre>
-     *    # Local   ->  _local
+     *    # Local   -&gt;  _local
      *
-     *    # Address ->  10.0.0.3,10.0.0.4
-     *              ->  10.0.0.*
+     *    # Address -&gt;  10.0.0.3,10.0.0.4
+     *              -&gt;  10.0.0.*
      *
-     *    # Names   ->  node_name_goes_here
-     *              ->  node_name_goes_*
+     *    # Names   -&gt;  node_name_goes_here
+     *              -&gt;  node_name_goes_*
      *
      *    # Attributes (set something like node.rack: 2 in the config)
-     *              ->  rack:2
-     *                  ->  ra*:2
-     *              ->  ra*:2*
+     *              -&gt;  rack:2
+     *                  -&gt;  ra*:2
+     *              -&gt;  ra*:2*
      * </pre>
      */
     public K addNode(String node) {
@@ -38,23 +38,23 @@ public abstract class AbstractMultiINodeActionBuilder<T extends Action, K> exten
     }
 
     /**
-     * Most cluster level APIs allow to specify which nodes to execute on (for example, getting the node stats for a node).
+     * <p>Most cluster level APIs allow to specify which nodes to execute on (for example, getting the node stats for a node).
      * Nodes can be identified in the APIs either using their internal node id, the node name, address, custom attributes,
      * or just the _local node receiving the request. For example, here are some sample values for node:
-     * <p/>
+     * </p>
      * <pre>
-     *    # Local   ->  _local
+     *    # Local   -&gt;  _local
      *
-     *    # Address ->  10.0.0.3,10.0.0.4
-     *              ->  10.0.0.*
+     *    # Address -&gt;  10.0.0.3,10.0.0.4
+     *              -&gt;  10.0.0.*
      *
-     *    # Names   ->  node_name_goes_here
-     *              ->  node_name_goes_*
+     *    # Names   -&gt;  node_name_goes_here
+     *              -&gt;  node_name_goes_*
      *
      *    # Attributes (set something like node.rack: 2 in the config)
-     *              ->  rack:2
-     *                  ->  ra*:2
-     *              ->  ra*:2*
+     *              -&gt;  rack:2
+     *                  -&gt;  ra*:2
+     *              -&gt;  ra*:2*
      * </pre>
      */
     public K addNode(Collection<? extends String> nodes) {

--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -53,7 +53,7 @@ public abstract class AbstractJestClient implements JestClient {
         if (servers.isEmpty()) {
             log.warning("No servers are currently available to connect.");
         } else if (log.isLoggable(Level.FINEST)) {
-            log.finest(MessageFormat.format("Server pool was updated to contain {} servers.", servers.size()));
+            log.finest(MessageFormat.format("Server pool was updated to contain {0} servers.", servers.size()));
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -1,20 +1,23 @@
 package io.searchbox.client;
 
 
+import java.text.MessageFormat;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.tuple.Pair;
+
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterators;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.exception.NoServerConfiguredException;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
-import org.apache.commons.lang3.tuple.Pair;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.Iterator;
-import java.util.Set;
-import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * @author Dogukan Sonmez
@@ -27,7 +30,7 @@ public abstract class AbstractJestClient implements JestClient {
             .setDateFormat(ELASTIC_SEARCH_DATE_FORMAT)
             .create();
 
-    private final static Logger log = LoggerFactory.getLogger(AbstractJestClient.class);
+    private final static Logger log = Logger.getLogger(AbstractJestClient.class.getName());
 
     // server pool = Pair of (pool size, pool iterator)
     private final AtomicReference<Pair<Integer, Iterator<String>>> serverPoolReference =
@@ -48,9 +51,9 @@ public abstract class AbstractJestClient implements JestClient {
         serverPoolReference.set(Pair.of(servers.size(), Iterators.cycle(servers)));
 
         if (servers.isEmpty()) {
-            log.warn("No servers are currently available to connect.");
-        } else if (log.isDebugEnabled()) {
-            log.debug("Server pool was updated to contain {} servers.", servers.size());
+            log.warning("No servers are currently available to connect.");
+        } else if (log.isLoggable(Level.FINEST)) {
+            log.finest(MessageFormat.format("Server pool was updated to contain {} servers.", servers.size()));
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -1,19 +1,20 @@
 package io.searchbox.client;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import io.searchbox.annotations.JestId;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.lang.reflect.Field;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import io.searchbox.annotations.JestId;
 
 /**
  * @author Dogukan Sonmez
@@ -21,7 +22,7 @@ import java.util.Map;
 public class JestResult {
 
     public static final String ES_METADATA_ID = "es_metadata_id";
-    private static final Logger log = LoggerFactory.getLogger(JestResult.class);
+    private static final Logger log = Logger.getLogger(JestResult.class.getName());
 
     protected JsonObject jsonObject;
     protected String jsonString;
@@ -208,14 +209,14 @@ public class JestResult {
                             field.set(obj, getAs(id, fieldType));
                         }
                     } catch (IllegalAccessException e) {
-                        log.error("Unhandled exception occurred while getting annotated id from source");
+                        log.severe("Unhandled exception occurred while getting annotated id from source");
                     }
                     break;
                 }
             }
 
         } catch (Exception e) {
-            log.error("Unhandled exception occurred while converting source to the object ." + type.getCanonicalName(), e);
+            log.log(Level.SEVERE, "Unhandled exception occurred while converting source to the object ." + type.getCanonicalName(), e);
         }
         return obj;
     }

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -1,21 +1,24 @@
 package io.searchbox.client.config.discovery;
 
+import java.text.MessageFormat;
+import java.util.LinkedHashSet;
+import java.util.Map.Entry;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.common.util.concurrent.AbstractScheduledService;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.config.ClientConfig;
 import io.searchbox.cluster.NodesInfo;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.LinkedHashSet;
-import java.util.Map.Entry;
-import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 /**
  * Discovers new nodes by calling NodesInfo API on the next available server
@@ -24,7 +27,7 @@ import java.util.regex.Pattern;
  */
 public class NodeChecker extends AbstractScheduledService {
 
-    private final static Logger log = LoggerFactory.getLogger(NodeChecker.class);
+    private final static Logger log = Logger.getLogger(NodeChecker.class.getName());
     private final static String PUBLISH_ADDRESS_KEY = "http_address";
     private final static Pattern INETSOCKETADDRESS_PATTERN = Pattern.compile("(?:inet\\[)(?:(?:[^:]+)?\\/)?([^:]+):(\\d+)\\]");
 
@@ -50,11 +53,12 @@ public class NodeChecker extends AbstractScheduledService {
 
     @Override
     protected void runOneIteration() throws Exception {
+
         JestResult result;
         try {
             result = client.execute(action);
         } catch (Exception e) {
-            log.error("Error executing NodesInfo!", e);
+            log.log(Level.SEVERE, "Error executing NodesInfo!", e);
             return;
             // do not elevate the exception since that will stop the scheduled calls.
             // throw new RuntimeException("Error executing NodesInfo!", e);
@@ -79,10 +83,10 @@ public class NodeChecker extends AbstractScheduledService {
                     }
                 }
             }
-            log.info("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ","));
+            log.info(MessageFormat.format("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ",")));
             client.setServers(httpHosts);
         } else {
-            log.warn("NodesInfo request resulted in error: {}", result.getErrorMessage());
+            log.warning(MessageFormat.format("NodesInfo request resulted in error: {}", result.getErrorMessage()));
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -83,10 +83,10 @@ public class NodeChecker extends AbstractScheduledService {
                     }
                 }
             }
-            log.info(MessageFormat.format("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ",")));
+            log.info(MessageFormat.format("Discovered {0} HTTP hosts: {1}", httpHosts.size(), StringUtils.join(httpHosts, ",")));
             client.setServers(httpHosts);
         } else {
-            log.warning(MessageFormat.format("NodesInfo request resulted in error: {}", result.getErrorMessage()));
+            log.warning(MessageFormat.format("NodesInfo request resulted in error: {0}", result.getErrorMessage()));
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -96,8 +96,8 @@ public class NodeChecker extends AbstractScheduledService {
     }
 
     /**
-     * Converts the Elasticsearch reported publish address in the format "inet[<hostname>:<port>]" or
-     * "inet[<hostname>/<hostaddress>:<port>]" to a normalized http address in the form "http://host:port".
+     * Converts the Elasticsearch reported publish address in the format "inet[&lt;hostnamegt;:&lt;port&gt;]" or
+     * "inet[&lt;hostname&gt;/&lt;hostaddressgt;:&lt;port&gt;]" to a normalized http address in the form "http://host:port".
      */
     protected String getHttpAddress(String httpAddress) {
         Matcher resolvedMatcher = INETSOCKETADDRESS_PATTERN.matcher(httpAddress);

--- a/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
@@ -1,16 +1,17 @@
 package io.searchbox.client.config.idle;
 
+import java.util.logging.Logger;
+
 import com.google.common.util.concurrent.AbstractScheduledService;
+
 import io.searchbox.client.config.ClientConfig;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Used to reap idle connections from the connection manager.
  */
 public class IdleConnectionReaper extends AbstractScheduledService {
 
-    final static Logger logger = LoggerFactory.getLogger(IdleConnectionReaper.class);
+    final static Logger logger = Logger.getLogger(IdleConnectionReaper.class.getName());
 
     private final ReapableConnectionManager reapableConnectionManager;
     private final ClientConfig clientConfig;
@@ -22,7 +23,7 @@ public class IdleConnectionReaper extends AbstractScheduledService {
 
     @Override
     protected void runOneIteration() throws Exception {
-        logger.debug("closing idle connections...");
+        logger.finest("closing idle connections...");
         reapableConnectionManager.closeIdleConnections(clientConfig.getMaxConnectionIdleTime(),
                                                        clientConfig.getMaxConnectionIdleTimeDurationTimeUnit());
     }

--- a/jest-common/src/main/java/io/searchbox/cluster/NodesShutdown.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesShutdown.java
@@ -33,7 +33,7 @@ public class NodesShutdown extends GenericResultAbstractAction {
          * By default, the shutdown will be executed after a 1 second delay (1s).
          * The delay can be customized by setting the delay parameter in a time value format.
          *
-         * @param value e.g.: "1s" -> 1 second, "10m" -> 10 minutes
+         * @param value e.g.: "1s" -&gt; 1 second, "10m" -&gt; 10 minutes
          */
         public Builder delay(String value) {
             return setParameter("delay", value);

--- a/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
@@ -6,13 +6,14 @@ import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
- * Allows to update cluster wide specific settings. Settings updated can either be persistent (applied cross restarts)
+ * <p>Allows to update cluster wide specific settings. Settings updated can either be persistent (applied cross restarts)
  * or transient (will not survive a full cluster restart). The cluster responds with the settings updated.
- * <br/>
- * <br/>
+ * </p>
+ * <p>
  * There is a specific list of settings that can be updated, please see
  * <a href="http://www.elastic.co/guide/en/elasticsearch/reference/current/cluster-update-settings.html#cluster-settings">Elasticsearch docs</a>
  * for more information.
+ * </p>
  *
  * @author cihat keser
  */

--- a/jest-common/src/main/java/io/searchbox/core/Bulk.java
+++ b/jest-common/src/main/java/io/searchbox/core/Bulk.java
@@ -20,15 +20,16 @@ import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.params.Parameters;
 
 /**
- * The bulk API makes it possible to perform many index/delete operations in a
+ * <p>The bulk API makes it possible to perform many index/delete operations in a
  * single API call. This can greatly increase the indexing speed.
- * <br/>
- * <br/>
+ * </p>
+ * <p>
  * Make sure that your source data (provided in Action instances) <b> does NOT
  * have unescaped line-breaks</b> (e.g.: <code>&quot;\n&quot;</code> or <code>&quot;\r\n&quot;</code>)
  * as doing so will break up the elasticsearch's bulk api format and bulk operation
  * will fail.
- *
+ * </p>
+ * 
  * @author Dogukan Sonmez
  * @author cihat keser
  */

--- a/jest-common/src/main/java/io/searchbox/core/Bulk.java
+++ b/jest-common/src/main/java/io/searchbox/core/Bulk.java
@@ -1,18 +1,23 @@
 package io.searchbox.core;
 
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.commons.lang3.StringUtils;
+
 import com.google.common.reflect.TypeToken;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.action.GenericResultAbstractAction;
-import io.searchbox.client.JestResult;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.*;
 
 /**
  * The bulk API makes it possible to perform many index/delete operations in a
@@ -29,7 +34,7 @@ import java.util.*;
  */
 public class Bulk extends AbstractAction<BulkResult> {
 
-    final static Logger log = LoggerFactory.getLogger(Bulk.class);
+    final static Logger log = Logger.getLogger(Bulk.class.getName());
     protected Collection<BulkableAction> bulkableActions;
 
     protected Bulk(Builder builder) {
@@ -89,7 +94,7 @@ public class Bulk extends AbstractAction<BulkResult> {
                         }
                     }
                 } catch (NullPointerException e) {
-                    log.debug("Could not retrieve '" + parameter + "' parameter from action.", e);
+                    log.log(Level.FINEST, "Could not retrieve '" + parameter + "' parameter from action.", e);
                 }
             }
 
@@ -138,10 +143,10 @@ public class Bulk extends AbstractAction<BulkResult> {
             {
                 result.setSucceeded(false);
                 result.setErrorMessage("One or more of the items in the Bulk request failed, check BulkResult.getItems() for more information.");
-                log.debug("Bulk operation failed due to one or more failed actions within the Bulk request");
+                log.finest("Bulk operation failed due to one or more failed actions within the Bulk request");
             } else {
                 result.setSucceeded(true);
-                log.debug("Bulk operation was successfull");
+                log.finest("Bulk operation was successful");
             }
         } else {
             result.setSucceeded(false);
@@ -152,7 +157,7 @@ public class Bulk extends AbstractAction<BulkResult> {
             if (result.getErrorMessage() == null) {
                 result.setErrorMessage(statusCode + " " + (reasonPhrase == null ? "null" : reasonPhrase));
             }
-            log.debug("Bulk operation failed with an HTTP error");
+            log.finest("Bulk operation failed with an HTTP error");
         }
         return result;
     }

--- a/jest-common/src/main/java/io/searchbox/core/Doc.java
+++ b/jest-common/src/main/java/io/searchbox/core/Doc.java
@@ -84,7 +84,7 @@ public class Doc {
      * By default, the _source field will be returned for every document (if stored).
      * Similar to the get API, you can retrieve only parts of the _source (or not at all)
      * by using the _source parameter. You can also use the url parameters _source,
-     * _source_include & _source_exclude to specify defaults, which will be used when there
+     * _source_include and _source_exclude to specify defaults, which will be used when there
      * are no per-document instructions.
      *
      */

--- a/jest-common/src/main/java/io/searchbox/core/Get.java
+++ b/jest-common/src/main/java/io/searchbox/core/Get.java
@@ -27,8 +27,8 @@ public class Get extends SingleResultAbstractDocumentTargetedAction {
     public static class Builder extends SingleResultAbstractDocumentTargetedAction.Builder<Get, Builder> {
 
         /**
-         * Index and ID parameters are mandatory but type is optional (_all will be used for type if left blank).
-         * <br/><br/>
+         * <p>Index and ID parameters are mandatory but type is optional (_all will be used for type if left blank).
+         * </p>
          * The get API allows for _type to be optional. Set it to _all in order to fetch the
          * first document matching the id across all types.
          */

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
@@ -1,25 +1,25 @@
 package io.searchbox.core.search.aggregation;
 
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
 
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 
-import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 
 /**
  * @author cfstout
  */
 public class FiltersAggregation extends BucketAggregation {
 
-    private final static Logger log = LoggerFactory.getLogger(FiltersAggregation.class);
+    private final static Logger log = Logger.getLogger(FiltersAggregation.class.getName());
     public static final String TYPE = "filters";
 
     private String name;
@@ -44,7 +44,7 @@ public class FiltersAggregation extends BucketAggregation {
                 addBucket(bucket.getKey(), bucket.getValue().getAsJsonObject());
             }
         } else {
-            log.debug("Skipped bucket parsing because Buckets element of JSON was neither Object nor Array.");
+            log.finest("Skipped bucket parsing because Buckets element of JSON was neither Object nor Array.");
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/indices/aliases/AbstractAliasMappingBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/AbstractAliasMappingBuilder.java
@@ -46,7 +46,7 @@ public abstract class AbstractAliasMappingBuilder<T extends AliasMapping, K> {
     }
 
     /**
-     * This method will add the given routing as both search & index routing.
+     * This method will add the given routing as both search and index routing.
      */
     public K addRouting(String routing) {
         this.indexRouting.add(routing);
@@ -55,7 +55,7 @@ public abstract class AbstractAliasMappingBuilder<T extends AliasMapping, K> {
     }
 
     /**
-     * This method will add the given routings as both search & index routing.
+     * This method will add the given routings as both search and index routing.
      */
     public K addRouting(List<String> routings) {
         this.indexRouting.addAll(routings);

--- a/jest-common/src/main/java/io/searchbox/indices/script/AbstractIndexedScript.java
+++ b/jest-common/src/main/java/io/searchbox/indices/script/AbstractIndexedScript.java
@@ -4,6 +4,7 @@ import io.searchbox.action.AbstractAction;
 import io.searchbox.action.GenericResultAbstractAction;
 
 import java.io.UnsupportedEncodingException;
+import java.util.logging.Level;
 
 import static io.searchbox.indices.script.ScriptLanguage.GROOVY;
 import static java.net.URLEncoder.encode;
@@ -28,7 +29,7 @@ public abstract class AbstractIndexedScript extends GenericResultAbstractAction 
         } catch (UnsupportedEncodingException e) {
             // unless CHARSET is overridden with a wrong value in a subclass,
             // this exception won't be thrown.
-            log.error("Error occurred while adding parameters to uri.", e);
+            log.log(Level.SEVERE, "Error occurred while adding parameters to uri.", e);
         }
         return finalUri;
     }

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -130,16 +130,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
         </dependency>

--- a/jest/src/main/java/io/searchbox/client/JestClientFactory.java
+++ b/jest/src/main/java/io/searchbox/client/JestClientFactory.java
@@ -1,11 +1,8 @@
 package io.searchbox.client;
 
-import com.google.gson.Gson;
-import io.searchbox.client.config.HttpClientConfig;
-import io.searchbox.client.config.discovery.NodeChecker;
-import io.searchbox.client.config.idle.HttpReapableConnectionManager;
-import io.searchbox.client.config.idle.IdleConnectionReaper;
-import io.searchbox.client.http.JestHttpClient;
+import java.util.Map;
+import java.util.logging.Logger;
+
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
@@ -27,24 +24,28 @@ import org.apache.http.impl.nio.reactor.IOReactorConfig;
 import org.apache.http.nio.conn.NHttpClientConnectionManager;
 import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.reactor.IOReactorException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
-import java.util.Map;
+import com.google.gson.Gson;
+
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.client.config.discovery.NodeChecker;
+import io.searchbox.client.config.idle.HttpReapableConnectionManager;
+import io.searchbox.client.config.idle.IdleConnectionReaper;
+import io.searchbox.client.http.JestHttpClient;
 
 /**
  * @author Dogukan Sonmez
  */
 public class JestClientFactory {
 
-    final static Logger log = LoggerFactory.getLogger(JestClientFactory.class);
+    final static Logger log = Logger.getLogger(JestClientFactory.class.getName());
     private HttpClientConfig httpClientConfig;
 
     public JestClient getObject() {
         JestHttpClient client = new JestHttpClient();
 
         if (httpClientConfig == null) {
-            log.debug("There is no configuration to create http client. Going to create simple client with default values");
+            log.finest("There is no configuration to create http client. Going to create simple client with default values");
             httpClientConfig = new HttpClientConfig.Builder("http://localhost:9200").build();
         }
 

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -1,6 +1,29 @@
 package io.searchbox.client.http;
 
+import java.io.IOException;
+import java.text.MessageFormat;
+import java.util.Map.Entry;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.HttpStatus;
+import org.apache.http.StatusLine;
+import org.apache.http.client.entity.EntityBuilder;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.entity.ContentType;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.util.EntityUtils;
+
 import com.google.gson.Gson;
+
 import io.searchbox.action.Action;
 import io.searchbox.client.AbstractJestClient;
 import io.searchbox.client.JestClient;
@@ -8,22 +31,6 @@ import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.http.apache.HttpDeleteWithEntity;
 import io.searchbox.client.http.apache.HttpGetWithEntity;
-import org.apache.http.HttpEntity;
-import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
-import org.apache.http.StatusLine;
-import org.apache.http.client.entity.EntityBuilder;
-import org.apache.http.client.methods.*;
-import org.apache.http.concurrent.FutureCallback;
-import org.apache.http.entity.ContentType;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
-import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Map.Entry;
 
 /**
  * @author Dogukan Sonmez
@@ -31,7 +38,7 @@ import java.util.Map.Entry;
  */
 public class JestHttpClient extends AbstractJestClient implements JestClient {
 
-    private final static Logger log = LoggerFactory.getLogger(JestHttpClient.class);
+    private final static Logger log = Logger.getLogger(JestHttpClient.class.getName());
     private final static HttpEntity DEFAULT_OK_RESPONSE = EntityBuilder.create().setText("{\"ok\" : true, \"found\" : true}").build();
     private final static HttpEntity DEFAULT_NOK_RESPONSE = EntityBuilder.create().setText("{\"ok\" : false, \"found\" : false}").build();
 
@@ -83,12 +90,12 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
         try {
             asyncClient.close();
         } catch (IOException ex) {
-            log.error("Exception occurred while shutting down the async client.", ex);
+            log.log(Level.SEVERE, "Exception occurred while shutting down the async client.", ex);
         }
         try {
             httpClient.close();
         } catch (IOException ex) {
-            log.error("Exception occurred while shutting down the sync client.", ex);
+            log.log(Level.SEVERE, "Exception occurred while shutting down the sync client.", ex);
         }
     }
 
@@ -96,7 +103,7 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
         String elasticSearchRestUrl = getRequestURL(getNextServer(), clientRequest.getURI());
         HttpUriRequest request = constructHttpMethod(clientRequest.getRestMethodName(), elasticSearchRestUrl, clientRequest.getData(gson));
 
-        log.debug("Request method={} url={}", clientRequest.getRestMethodName(), elasticSearchRestUrl);
+        log.finest(MessageFormat.format("Request method={} url={}", clientRequest.getRestMethodName(), elasticSearchRestUrl));
 
         // add headers added to action
         for (Entry<String, Object> header : clientRequest.getHeaders().entrySet()) {
@@ -111,19 +118,19 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
 
         if (methodName.equalsIgnoreCase("POST")) {
             httpUriRequest = new HttpPost(url);
-            log.debug("POST method created based on client request");
+            log.finest("POST method created based on client request");
         } else if (methodName.equalsIgnoreCase("PUT")) {
             httpUriRequest = new HttpPut(url);
-            log.debug("PUT method created based on client request");
+            log.finest("PUT method created based on client request");
         } else if (methodName.equalsIgnoreCase("DELETE")) {
             httpUriRequest = new HttpDeleteWithEntity(url);
-            log.debug("DELETE method created based on client request");
+            log.finest("DELETE method created based on client request");
         } else if (methodName.equalsIgnoreCase("GET")) {
             httpUriRequest = new HttpGetWithEntity(url);
-            log.debug("GET method created based on client request");
+            log.finest("GET method created based on client request");
         } else if (methodName.equalsIgnoreCase("HEAD")) {
             httpUriRequest = new HttpHead(url);
-            log.debug("HEAD method created based on client request");
+            log.finest("HEAD method created based on client request");
         }
 
         if (httpUriRequest != null && httpUriRequest instanceof HttpEntityEnclosingRequestBase && payload != null) {
@@ -197,13 +204,13 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
 
         @Override
         public void failed(final Exception ex) {
-            log.error("Exception occurred during async execution.", ex);
+            log.log(Level.SEVERE, "Exception occurred during async execution.", ex);
             resultHandler.failed(ex);
         }
 
         @Override
         public void cancelled() {
-            log.warn("Async execution was cancelled; this is not expected to occur under normal operation.");
+            log.warning("Async execution was cancelled; this is not expected to occur under normal operation.");
         }
     }
 

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -103,7 +103,7 @@ public class JestHttpClient extends AbstractJestClient implements JestClient {
         String elasticSearchRestUrl = getRequestURL(getNextServer(), clientRequest.getURI());
         HttpUriRequest request = constructHttpMethod(clientRequest.getRestMethodName(), elasticSearchRestUrl, clientRequest.getData(gson));
 
-        log.finest(MessageFormat.format("Request method={} url={}", clientRequest.getRestMethodName(), elasticSearchRestUrl));
+        log.finest(MessageFormat.format("Request method={0} url={1}", clientRequest.getRestMethodName(), elasticSearchRestUrl));
 
         // add headers added to action
         for (Entry<String, Object> header : clientRequest.getHeaders().entrySet()) {

--- a/pom.xml
+++ b/pom.xml
@@ -133,9 +133,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>


### PR DESCRIPTION
This removes all SLF4J references in the source code and use
java.util.logging in order to reduce dependencies.

In addition, I have corrected the JavaDoc errors so it won't fail.