### PR TITLE
Created Jest-gae plugin that enables Jest on Google App Engine

### DIFF
--- a/jest-gae/pom.xml
+++ b/jest-gae/pom.xml
@@ -1,0 +1,144 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.searchbox</groupId>
+    <artifactId>jest-gae</artifactId>
+    <packaging>jar</packaging>
+    <version>0.1.7-SNAPSHOT</version>
+    <name>Jest GAE Jar</name>
+    <description>ElasticSearch Java REST client -  GAE library package</description>
+    <url>https://github.com/searchbox-io/Jest</url>
+
+    <licenses>
+        <license>
+            <name>The Apache Software License, Version 2.0</name>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <distribution>repo</distribution>
+        </license>
+    </licenses>
+
+    <scm>
+        <connection>scm:git:git@github.com:searchbox-io/Jest.git</connection>
+        <developerConnection>scm:git:git@github.com:searchbox-io/Jest.git</developerConnection>
+        <url>git@github.com:searchbox-io/Jest.git</url>
+    </scm>
+
+    <properties>
+        <appengine.version>1.9.22</appengine.version>
+        <google.http.client.version>1.20.0</google.http.client.version>
+    </properties>
+
+    <developers>
+        <developer>
+            <id>TheKingOfTheEast</id>
+            <name>Dogukan Sonmez</name>
+            <email>dogukansonmez@yahoo.com</email>
+        </developer>
+        <developer>
+            <id>ferhatsb</id>
+            <name>Ferhat Sobay</name>
+            <email>ferhat@searchbox.io</email>
+        </developer>
+        <developer>
+            <id>kramer</id>
+            <name>Cihat Keser</name>
+            <email>info@cihatkeser.com</email>
+            <url>http://about.cihatkeser.com</url>
+        </developer>
+    </developers>
+
+    <parent>
+        <groupId>io.searchbox</groupId>
+        <artifactId>jest-parent</artifactId>
+        <version>0.1.7-SNAPSHOT</version>
+    </parent>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-api-1.0-sdk</artifactId>
+            <version>${appengine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.appengine</groupId>
+            <artifactId>appengine-endpoints</artifactId>
+            <version>${appengine.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.searchbox</groupId>
+            <artifactId>jest-common</artifactId>
+        </dependency>
+
+        <!-- Http components -->
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client</artifactId>
+            <version>${google.http.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-appengine</artifactId>
+            <version>${google.http.client.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.http-client</groupId>
+            <artifactId>google-http-client-jackson2</artifactId>
+            <version>${google.http.client.version}</version>
+        </dependency>
+
+        <!-- Testing Dependencies -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.littleshoot</groupId>
+            <artifactId>littleproxy</artifactId>
+            <exclusions>
+                <exclusion>
+                    <artifactId>slf4j-log4j12</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>log4j</artifactId>
+                    <groupId>log4j</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-all</artifactId>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/jest-gae/src/main/java/com/searchly/jestgae/GaeClientConfig.java
+++ b/jest-gae/src/main/java/com/searchly/jestgae/GaeClientConfig.java
@@ -1,0 +1,57 @@
+package com.searchly.jestgae;
+
+import com.google.appengine.api.urlfetch.FetchOptions;
+import io.searchbox.client.config.ClientConfig;
+
+import java.util.Collection;
+
+/**
+ * @author Scopewriter
+ */
+public class GaeClientConfig extends ClientConfig {
+
+    private final FetchOptions fetchOptions;
+
+    /**
+     * There is no need for connection pool management etc. as GAE's URL Fetch Service manages it.
+     * Only FetchOptions, which contains the request timeout, follow redirects etc. is configurable.
+     * @param builder
+     */
+    public GaeClientConfig(Builder builder) {
+        super(builder);
+        this.fetchOptions = builder.fetchOptions;
+    }
+
+    public FetchOptions getFetchOptions() {
+        return fetchOptions;
+    }
+
+    public static class Builder extends ClientConfig.AbstractBuilder<GaeClientConfig, Builder> {
+
+        private FetchOptions fetchOptions;
+
+        public Builder(GaeClientConfig httpClientConfig) {
+            super(httpClientConfig);
+        }
+
+        public Builder(Collection<String> serverUris) {
+            super(serverUris);
+        }
+
+        public Builder(String serverUri) {
+            super(serverUri);
+        }
+
+        public Builder fetchOptions(FetchOptions fetchOptions) {
+            this.fetchOptions = fetchOptions;
+            return this;
+        }
+
+        public GaeClientConfig build() {
+            return new GaeClientConfig(this);
+        }
+
+    }
+
+}
+

--- a/jest-gae/src/main/java/com/searchly/jestgae/JestClientFactory.java
+++ b/jest-gae/src/main/java/com/searchly/jestgae/JestClientFactory.java
@@ -1,0 +1,65 @@
+package com.searchly.jestgae;
+
+import com.google.appengine.api.urlfetch.FetchOptions;
+import com.google.gson.Gson;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.config.discovery.NodeChecker;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author Scopewriter
+ */
+public class JestClientFactory {
+
+    final static Logger log = LoggerFactory.getLogger(JestClientFactory.class);
+    private GaeClientConfig gaeClientConfig;
+
+    public JestClient getObject() {
+        JestGaeClient client = new JestGaeClient();
+
+        if (gaeClientConfig == null) {
+            log.debug("There is no configuration to create http client. Going to create simple client with default values");
+            gaeClientConfig = new GaeClientConfig.Builder("http://localhost:9200").build();
+        }
+
+        client.setRequestCompressionEnabled(gaeClientConfig.isRequestCompressionEnabled());
+        client.setServers(gaeClientConfig.getServerList());
+
+        // Set Fetch options which contains the request timeout, follow redirects etc.
+        FetchOptions fetchOptions = gaeClientConfig.getFetchOptions();
+        if (fetchOptions == null) {
+            log.info("Using default FetchOptions instance");
+            client.setFetchOptions(FetchOptions.Builder.withDefaults());
+        } else {
+            log.info("Using custom FetchOptions instance");
+            client.setFetchOptions(fetchOptions);
+        }
+
+        // set custom gson instance
+        Gson gson = gaeClientConfig.getGson();
+        if (gson == null) {
+            log.info("Using default GSON instance");
+        } else {
+            log.info("Using custom GSON instance");
+            client.setGson(gson);
+        }
+
+        // set discovery (should be set after setting the httpClient on jestClient)
+        if (gaeClientConfig.isDiscoveryEnabled()) {
+            log.info("Node Discovery enabled...");
+            NodeChecker nodeChecker = new NodeChecker(client, gaeClientConfig);
+            client.setNodeChecker(nodeChecker);
+            nodeChecker.startAsync();
+            nodeChecker.awaitRunning();
+        } else {
+            log.info("Node Discovery disabled...");
+        }
+
+        return client;
+    }
+
+    public void setGaeClientConfig(GaeClientConfig gaeClientConfig) {
+        this.gaeClientConfig = gaeClientConfig;
+    }
+}

--- a/jest-gae/src/main/java/com/searchly/jestgae/JestGaeClient.java
+++ b/jest-gae/src/main/java/com/searchly/jestgae/JestGaeClient.java
@@ -1,0 +1,136 @@
+package com.searchly.jestgae;
+
+import com.google.appengine.api.urlfetch.*;
+import com.google.gson.Gson;
+import io.searchbox.action.Action;
+import io.searchbox.client.AbstractJestClient;
+import io.searchbox.client.JestClient;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.JestResultHandler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Map.Entry;
+
+/**
+ * @author Scopewriter
+ */
+public class JestGaeClient extends AbstractJestClient implements JestClient {
+
+    private final static Logger log = LoggerFactory.getLogger(JestGaeClient.class);
+    private final static String DEFAULT_OK_RESPONSE = "{\"ok\" : true, \"found\" : true}";
+    private final static String DEFAULT_NOK_RESPONSE = "{\"ok\" : false, \"found\" : false}";
+
+    protected final static String REQUEST_CONTENT_TYPE = "application/json; charset=utf-8";
+
+    private URLFetchService urlFetchService = URLFetchServiceFactory.getURLFetchService();
+    private FetchOptions fetchOptions;
+
+    /**
+     * @throws java.io.IOException in case of a problem or the connection was aborted during request,
+     *                     or in case of a problem while reading the response stream
+     */
+    @Override
+    public <T extends JestResult> T execute(Action<T> clientRequest) throws IOException {
+        HTTPRequest request = prepareRequest(clientRequest);
+        HTTPResponse response = urlFetchService.fetch(request);
+        return deserializeResponse(response, clientRequest, request.getMethod());
+    }
+
+    @Override
+    public <T extends JestResult> void executeAsync(final Action<T> clientRequest, final JestResultHandler<T> resultHandler) {
+        throw new UnsupportedOperationException("Jest-gae does not yet support async execution, sorry!");
+    }
+
+    @Override
+    public void shutdownClient() {
+        super.shutdownClient();
+    }
+
+    protected <T extends JestResult> HTTPRequest prepareRequest(final Action<T> clientRequest) throws MalformedURLException {
+        String elasticSearchRestUrl = getRequestURL(getNextServer(), clientRequest.getURI());
+        URL url = new URL(elasticSearchRestUrl);
+        HTTPRequest request = constructHttpMethod(clientRequest.getRestMethodName(), url, clientRequest.getData(gson));
+        log.debug("Request method={} url={}", clientRequest.getRestMethodName(), elasticSearchRestUrl);
+
+        // add headers to request
+        for (Entry<String, Object> header : clientRequest.getHeaders().entrySet()) {
+            request.addHeader(new HTTPHeader(header.getKey(), header.getValue().toString()));
+        }
+
+        return request;
+    }
+
+    protected HTTPRequest constructHttpMethod(String methodName, URL url, String payload) {
+        HTTPRequest httpRequest = null;
+        if (methodName.equalsIgnoreCase("POST")) {
+            httpRequest = new HTTPRequest(url, HTTPMethod.POST, fetchOptions);
+            log.debug("POST method created based on client request");
+        } else if (methodName.equalsIgnoreCase("PUT")) {
+            httpRequest = new HTTPRequest(url, HTTPMethod.PUT, fetchOptions);
+            log.debug("PUT method created based on client request");
+        } else if (methodName.equalsIgnoreCase("DELETE")) {
+            httpRequest = new HTTPRequest(url, HTTPMethod.DELETE, fetchOptions);
+            log.debug("DELETE method created based on client request");
+        } else if (methodName.equalsIgnoreCase("GET")) {
+            httpRequest = new HTTPRequest(url, HTTPMethod.GET, fetchOptions);
+            log.debug("GET method created based on client request");
+        } else if (methodName.equalsIgnoreCase("HEAD")) {
+            httpRequest = new HTTPRequest(url, HTTPMethod.HEAD, fetchOptions);
+            log.debug("HEAD method created based on client request");
+        }
+
+        if (httpRequest != null && payload != null) {
+            httpRequest.setPayload(payload.getBytes());
+            httpRequest.setHeader(new HTTPHeader("Content-type", REQUEST_CONTENT_TYPE));
+        }
+
+        return httpRequest;
+    }
+
+    private <T extends JestResult> T deserializeResponse(HTTPResponse response, Action<T> clientRequest, HTTPMethod httpMethod) throws IOException {
+        // If head method returns no content, content is added according to response code
+        String responseBody = null;
+        if (HTTPMethod.HEAD.equals(httpMethod)) {
+            if (response.getContent() == null) {
+                switch (response.getResponseCode()) {
+                    case 200:
+                        responseBody = DEFAULT_OK_RESPONSE;
+                        break;
+                    case 404:
+                        responseBody = DEFAULT_NOK_RESPONSE;
+                        break;
+                }
+            }
+        } else {
+            responseBody = response.getContent() == null ? null : new String(response.getContent(), "utf-8");
+        }
+
+        return clientRequest.createNewElasticSearchResult(
+                responseBody,
+                response.getResponseCode(),
+                "", // No StatusMessage or ReasonPhrase in the GAE HTTPResponse
+                gson
+        );
+    }
+
+    public FetchOptions getFetchOptions() {
+        return fetchOptions;
+    }
+
+    public void setFetchOptions(FetchOptions fetchOptions) {
+        this.fetchOptions = fetchOptions;
+    }
+
+    public Gson getGson() {
+        return gson;
+    }
+
+    public void setGson(Gson gson) {
+        this.gson = gson;
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
         <module>jest-common</module>
         <module>jest</module>
         <module>jest-droid</module>
+		<module>jest-gae</module>
     </modules>
 
     <licenses>


### PR DESCRIPTION
This Jest-gae plugin uses Google's URLFetchService instead of apache HttpClient which enables jest to run on Google App Engine.