### PR TITLE
Return source as String + Cleanup

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -3,10 +3,8 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.searchbox</groupId>
     <artifactId>jest-common</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
     <name>Jest Common Jar</name>
     <description>ElasticSearch Java REST client - shared library package</description>
     <url>https://github.com/searchbox-io/Jest</url>

--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -1,6 +1,5 @@
 package io.searchbox.action;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
@@ -1,12 +1,11 @@
 package io.searchbox.action;
 
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
+
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author cihat keser

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiTypeActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiTypeActionBuilder.java
@@ -3,7 +3,6 @@ package io.searchbox.action;
 import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Set;
 

--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -117,15 +117,17 @@ public class JestResult {
         setJsonObject(new JsonParser().parse(json).getAsJsonObject());
     }
     
-    public String getSourceString() {
-    	if(isSucceeded) {
-    		JsonElement source = getSourceAsObject(JsonElement.class);
-    		if(source != null && source instanceof JsonObject) {
-    			((JsonObject) source).remove(ES_METADATA_ID);
-    		}
-    		return source == null ? null : source.toString();
-    	}
-    	return null;
+    public String getSourceAsString() {
+    	String[] keys = getKeys();
+        if(!isSucceeded || jsonObject == null || keys == null || keys.length == 0 || !jsonObject.has(keys[0])) {
+            return null;
+        }
+
+        JsonElement obj = jsonObject.get(keys[0]);
+        for (int i = 1; i < keys.length; i++) {
+            obj = ((JsonObject) obj).get(keys[i]);
+        }
+        return obj.toString();
     }
 
     public <T> T getSourceAsObject(Class<T> clazz) {

--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -116,6 +116,17 @@ public class JestResult {
         String json = gson.toJson(resultMap, Map.class);
         setJsonObject(new JsonParser().parse(json).getAsJsonObject());
     }
+    
+    public String getSourceString() {
+    	if(isSucceeded) {
+    		JsonElement source = getSourceAsObject(JsonElement.class);
+    		if(source != null && source instanceof JsonObject) {
+    			((JsonObject) source).remove(ES_METADATA_ID);
+    		}
+    		return source == null ? null : source.toString();
+    	}
+    	return null;
+    }
 
     public <T> T getSourceAsObject(Class<T> clazz) {
         T sourceAsObject = null;
@@ -271,7 +282,7 @@ public class JestResult {
     }
 
     protected String[] getKeys() {
-        return pathToResult == null ? null : (pathToResult + "").split("/");
+        return pathToResult == null ? null : pathToResult.split("/");
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
@@ -52,7 +52,6 @@ public class UpdateSettings extends GenericResultAbstractAction {
             return false;
         }
 
-        UpdateSettings rhs = (UpdateSettings) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Bulk.java
+++ b/jest-common/src/main/java/io/searchbox/core/Bulk.java
@@ -6,7 +6,6 @@ import com.google.gson.JsonObject;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.action.GenericResultAbstractAction;
-import io.searchbox.client.JestResult;
 import io.searchbox.params.Parameters;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/jest-common/src/main/java/io/searchbox/core/BulkResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/BulkResult.java
@@ -7,7 +7,6 @@ import io.searchbox.client.JestResult;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;

--- a/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
+++ b/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
@@ -52,7 +52,6 @@ public class DeleteByQuery extends GenericResultAbstractAction {
             return false;
         }
 
-        DeleteByQuery rhs = (DeleteByQuery) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Explain.java
+++ b/jest-common/src/main/java/io/searchbox/core/Explain.java
@@ -45,7 +45,6 @@ public class Explain extends SingleResultAbstractDocumentTargetedAction {
             return false;
         }
 
-        Explain rhs = (Explain) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Index.java
+++ b/jest-common/src/main/java/io/searchbox/core/Index.java
@@ -63,7 +63,6 @@ public class Index extends SingleResultAbstractDocumentTargetedAction implements
             return false;
         }
 
-        Index rhs = (Index) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/MoreLikeThis.java
+++ b/jest-common/src/main/java/io/searchbox/core/MoreLikeThis.java
@@ -46,7 +46,6 @@ public class MoreLikeThis extends GenericResultAbstractDocumentTargetedAction {
             return false;
         }
 
-        MoreLikeThis rhs = (MoreLikeThis) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/MultiGet.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiGet.java
@@ -73,7 +73,6 @@ public class MultiGet extends GenericResultAbstractAction {
             return false;
         }
 
-        MultiGet rhs = (MultiGet) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Percolate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Percolate.java
@@ -50,7 +50,6 @@ public class Percolate extends GenericResultAbstractAction {
             return false;
         }
 
-        Percolate rhs = (Percolate) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
@@ -62,7 +62,6 @@ public class SearchScroll extends GenericResultAbstractAction {
             return false;
         }
 
-        SearchScroll rhs = (SearchScroll) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Suggest.java
+++ b/jest-common/src/main/java/io/searchbox/core/Suggest.java
@@ -57,7 +57,6 @@ public class Suggest extends AbstractAction<SuggestResult> {
             return false;
         }
 
-        Suggest rhs = (Suggest) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/core/Validate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Validate.java
@@ -53,7 +53,6 @@ public class Validate extends GenericResultAbstractAction {
             return false;
         }
 
-        Validate rhs = (Validate) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/indices/Analyze.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Analyze.java
@@ -50,7 +50,6 @@ public class Analyze extends GenericResultAbstractAction {
             return false;
         }
 
-        Analyze rhs = (Analyze) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
@@ -48,7 +48,6 @@ public class PutMapping extends GenericResultAbstractAction {
             return false;
         }
 
-        PutMapping rhs = (PutMapping) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/indices/script/CreateIndexedScript.java
+++ b/jest-common/src/main/java/io/searchbox/indices/script/CreateIndexedScript.java
@@ -4,13 +4,9 @@ import com.google.common.io.CharStreams;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.searchbox.action.AbstractAction;
-import io.searchbox.action.GenericResultAbstractAction;
 
 import java.io.*;
 import java.nio.charset.Charset;
-
-import static io.searchbox.indices.script.ScriptLanguage.GROOVY;
-import static java.net.URLEncoder.encode;
 
 public class CreateIndexedScript extends AbstractIndexedScript {
 

--- a/jest-common/src/main/java/io/searchbox/indices/script/DeleteIndexedScript.java
+++ b/jest-common/src/main/java/io/searchbox/indices/script/DeleteIndexedScript.java
@@ -1,13 +1,5 @@
 package io.searchbox.indices.script;
 
-import io.searchbox.action.AbstractAction;
-import io.searchbox.action.GenericResultAbstractAction;
-
-import java.io.UnsupportedEncodingException;
-
-import static io.searchbox.indices.script.ScriptLanguage.GROOVY;
-import static java.net.URLEncoder.encode;
-
 public class DeleteIndexedScript extends AbstractIndexedScript {
 
     protected DeleteIndexedScript(Builder builder) {

--- a/jest-common/src/main/java/io/searchbox/indices/settings/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/indices/settings/UpdateSettings.java
@@ -41,7 +41,6 @@ public class UpdateSettings extends IndicesSettingsAbstractAction {
             return false;
         }
 
-        UpdateSettings rhs = (UpdateSettings) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/main/java/io/searchbox/indices/template/PutTemplate.java
+++ b/jest-common/src/main/java/io/searchbox/indices/template/PutTemplate.java
@@ -40,7 +40,6 @@ public class PutTemplate extends TemplateAction {
             return false;
         }
 
-        PutTemplate rhs = (PutTemplate) obj;
         return new EqualsBuilder()
                 .appendSuper(super.equals(obj))
                 .isEquals();

--- a/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
@@ -129,7 +129,7 @@ public class JestResultTest {
     }
     
     @Test
-    public void getGetSourceString() {
+    public void getGetSourceAsString() {
         String response = "{\n" +
                 "    \"_index\" : \"twitter\",\n" +
                 "    \"_type\" : \"tweet\",\n" +
@@ -150,11 +150,11 @@ public class JestResultTest {
                 "\"postDate\":\"2009-11-15T14:12:12\"," +
                 "\"message\":\"trying out Elastic Search\"" +
                 "}";
-        assertEquals(onlySource, result.getSourceString());
+        assertEquals(onlySource, result.getSourceAsString());
     }
     
     @Test
-    public void getGetSourceStringArray() {
+    public void getGetSourceAsStringArray() {
         String response = "{\n" +
                 "    \"_index\" : \"twitter\",\n" +
                 "    \"_type\" : \"tweet\",\n" +
@@ -175,11 +175,11 @@ public class JestResultTest {
                 "{\"user\":\"bello\"}," +
                 "{\"user\":\"ionex\"}" +
                 "]";
-        assertEquals(onlySource, result.getSourceString());
+        assertEquals(onlySource, result.getSourceAsString());
     }
     
     @Test
-    public void getGetSourceStringNoResult() {
+    public void getGetSourceAsStringNoResult() {
         String response = "{\n" +
                 "    \"_index\" : \"twitter\",\n" +
                 "    \"_type\" : \"tweet\",\n" +
@@ -189,7 +189,7 @@ public class JestResultTest {
         result.setJsonMap(new Gson().fromJson(response, Map.class));
         result.setPathToResult("_source");
         result.setSucceeded(true);
-        assertNull(result.getSourceString());
+        assertNull(result.getSourceAsString());
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
@@ -1,17 +1,19 @@
 package io.searchbox.client;
 
+import static org.junit.Assert.*;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import io.searchbox.annotations.JestId;
+
 import org.junit.Test;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-
-import static junit.framework.Assert.*;
 
 /**
  * @author Dogukan Sonmez
@@ -124,6 +126,70 @@ public class JestResultTest {
         assertEquals("kimchy", twitter.getUser());
         assertEquals("trying out Elastic Search", twitter.getMessage());
         assertEquals("2009-11-15T14:12:12", twitter.getPostDate());
+    }
+    
+    @Test
+    public void getGetSourceString() {
+        String response = "{\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_type\" : \"tweet\",\n" +
+                "    \"_id\" : \"1\", \n" +
+                "    \"_source\" : {\n" +
+                "        \"user\" : \"kimchy\",\n" +
+                "        \"postDate\" : \"2009-11-15T14:12:12\",\n" +
+                "        \"message\" : \"trying out Elastic Search\"\n" +
+                "    }\n" +
+                "}\n";
+        
+        result.setJsonMap(new Gson().fromJson(response, Map.class));
+        result.setPathToResult("_source");
+        result.setSucceeded(true);
+        
+        String onlySource = "{" +
+                "\"user\":\"kimchy\"," +
+                "\"postDate\":\"2009-11-15T14:12:12\"," +
+                "\"message\":\"trying out Elastic Search\"" +
+                "}";
+        assertEquals(onlySource, result.getSourceString());
+    }
+    
+    @Test
+    public void getGetSourceStringArray() {
+        String response = "{\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_type\" : \"tweet\",\n" +
+                "    \"_id\" : \"1\", \n" +
+                "    \"_source\" : [" +
+                "        { \"user\" : \"kimch\" }, " +
+                "        { \"user\" : \"bello\" }," +
+                "        { \"user\" : \"ionex\" }" +
+                "    ]\n" +
+                "}\n";
+        
+        result.setJsonMap(new Gson().fromJson(response, Map.class));
+        result.setPathToResult("_source");
+        result.setSucceeded(true);
+        
+        String onlySource = "[" +
+                "{\"user\":\"kimch\"}," +
+                "{\"user\":\"bello\"}," +
+                "{\"user\":\"ionex\"}" +
+                "]";
+        assertEquals(onlySource, result.getSourceString());
+    }
+    
+    @Test
+    public void getGetSourceStringNoResult() {
+        String response = "{\n" +
+                "    \"_index\" : \"twitter\",\n" +
+                "    \"_type\" : \"tweet\",\n" +
+                "    \"_id\" : \"1\" \n" +
+                "}\n";
+        
+        result.setJsonMap(new Gson().fromJson(response, Map.class));
+        result.setPathToResult("_source");
+        result.setSucceeded(true);
+        assertNull(result.getSourceString());
     }
 
     @Test
@@ -418,7 +484,7 @@ public class JestResultTest {
         result.setJsonMap(new Gson().fromJson(response, Map.class));
         result.setPathToResult("count");
         Double actual = result.extractSource().get(0).getAsDouble();
-        assertEquals(1.0, actual);
+        assertEquals(1.0, actual, 0.01);
     }
 
     @Test
@@ -435,7 +501,7 @@ public class JestResultTest {
         result.setPathToResult("count");
         result.setSucceeded(true);
         Double count = result.getSourceAsObject(Double.class);
-        assertEquals(1.0, count);
+        assertEquals(1.0, count, 0.01);
     }
 
     @Test

--- a/jest-droid/pom.xml
+++ b/jest-droid/pom.xml
@@ -3,10 +3,8 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.searchbox</groupId>
     <artifactId>jest-droid</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
     <name>Jest Android Jar</name>
     <description>ElasticSearch Java REST client - Android library package</description>
     <url>https://github.com/searchbox-io/Jest</url>

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -3,10 +3,8 @@
 
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>io.searchbox</groupId>
     <artifactId>jest</artifactId>
     <packaging>jar</packaging>
-    <version>1.0.0-SNAPSHOT</version>
     <name>Jest Apache HC Jar</name>
     <description>ElasticSearch Java REST client - Apache HTTP Client package</description>
     <url>https://github.com/searchbox-io/Jest</url>

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -1,19 +1,21 @@
 package io.searchbox.client.http;
 
-import com.google.gson.Gson;
 import io.searchbox.action.Action;
 import io.searchbox.client.AbstractJestClient;
-import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.http.apache.HttpDeleteWithEntity;
 import io.searchbox.client.http.apache.HttpGetWithEntity;
-import org.apache.http.HttpEntity;
+import java.io.IOException;
+import java.util.Map.Entry;
 import org.apache.http.HttpResponse;
-import org.apache.http.HttpStatus;
 import org.apache.http.StatusLine;
 import org.apache.http.client.entity.EntityBuilder;
-import org.apache.http.client.methods.*;
+import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.concurrent.FutureCallback;
 import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.CloseableHttpClient;
@@ -21,15 +23,13 @@ import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
-import java.util.Map.Entry;
+import com.google.gson.Gson;
 
 /**
  * @author Dogukan Sonmez
  * @author cihat keser
  */
-public class JestHttpClient extends AbstractJestClient implements JestClient {
+public class JestHttpClient extends AbstractJestClient {
 
     private final static Logger log = LoggerFactory.getLogger(JestHttpClient.class);
 


### PR DESCRIPTION
Adds method <code>JestResult#getSourceString()</code> (incl. tests in <code>JestResultTest</code>)

In addition:
- cleaned up some unused imports and variables
- make use of <code>org.junit</code> instead of <code>junit.assert</code>.
- JestHttpClient needs not to implement JestClient, as it already extends AbstractJestClient which implements it.