### PR TITLE
Es 2.0

### DIFF
--- a/jest/src/test/java/io/searchbox/core/GetIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/GetIntegrationTest.java
@@ -37,7 +37,6 @@ public class GetIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    @Ignore(value = "looks like this is a bug in es2, tracking as https://github.com/elastic/elasticsearch/issues/14177")
     public void getWithSpecialCharacterInDocId() throws IOException {
         final String documentId = "asd/qwe";
         IndexResponse indexResponse = client().index(new IndexRequest(

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <elasticsearch.version>2.0.0-rc1</elasticsearch.version>
+        <elasticsearch.version>2.0.0</elasticsearch.version>
 
         <lucene.version>5.2.1</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>


### PR DESCRIPTION
ES 2.0 is now released in maven, so upgrading. They have also fixed the bug with "/" in the document id - adding the test back.