### PR TITLE
Improve error message when a proxy returns text/html

### DIFF
--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -174,7 +174,7 @@ public class JestHttpClient extends AbstractJestClient {
             T jestResult = null;
             try {
                 jestResult = deserializeResponse(response, clientRequest);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 failed(e);
             }
             if (jestResult != null) resultHandler.completed(jestResult);

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -8,6 +8,9 @@ import io.searchbox.client.http.apache.HttpDeleteWithEntity;
 import io.searchbox.client.http.apache.HttpGetWithEntity;
 import java.io.IOException;
 import java.util.Map.Entry;
+
+import org.apache.http.Header;
+import org.apache.http.HttpRequest;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.entity.EntityBuilder;
@@ -47,7 +50,7 @@ public class JestHttpClient extends AbstractJestClient {
         HttpUriRequest request = prepareRequest(clientRequest);
         HttpResponse response = httpClient.execute(request);
 
-        return deserializeResponse(response, clientRequest);
+        return deserializeResponse(response, request, clientRequest);
     }
 
     @Override
@@ -59,7 +62,7 @@ public class JestHttpClient extends AbstractJestClient {
         }
 
         HttpUriRequest request = prepareRequest(clientRequest);
-        asyncClient.execute(request, new DefaultCallback<T>(clientRequest, resultHandler));
+        asyncClient.execute(request, new DefaultCallback<T>(clientRequest, request, resultHandler));
     }
 
     @Override
@@ -126,14 +129,27 @@ public class JestHttpClient extends AbstractJestClient {
         return httpUriRequest;
     }
 
-    private <T extends JestResult> T deserializeResponse(HttpResponse response, Action<T> clientRequest) throws IOException {
+    private <T extends JestResult> T deserializeResponse(HttpResponse response, final HttpRequest httpRequest, Action<T> clientRequest) throws IOException {
         StatusLine statusLine = response.getStatusLine();
-        return clientRequest.createNewElasticSearchResult(
-                response.getEntity() == null ? null : EntityUtils.toString(response.getEntity()),
-                statusLine.getStatusCode(),
-                statusLine.getReasonPhrase(),
-                gson
-        );
+        try {
+            return clientRequest.createNewElasticSearchResult(
+                    response.getEntity() == null ? null : EntityUtils.toString(response.getEntity()),
+                    statusLine.getStatusCode(),
+                    statusLine.getReasonPhrase(),
+                    gson
+            );
+        } catch (com.google.gson.JsonSyntaxException e) {
+            for (Header header : response.getAllHeaders()) {
+                final String mimeType = header.getValue();
+                if (!mimeType.startsWith("application/json")) {
+                    // probably a proxy that responded in text/html
+                    final String message = "Request " + httpRequest.toString() + " yielded " + mimeType
+                            + ", should be json: " + statusLine.toString();
+                    throw new IOException(message, e);
+                }
+            }
+            throw e;
+        }
     }
 
     public CloseableHttpClient getHttpClient() {
@@ -162,10 +178,12 @@ public class JestHttpClient extends AbstractJestClient {
 
     protected class DefaultCallback<T extends JestResult> implements FutureCallback<HttpResponse> {
         private final Action<T> clientRequest;
+        private final HttpRequest request;
         private final JestResultHandler<? super T> resultHandler;
 
-        public DefaultCallback(Action<T> clientRequest, JestResultHandler<? super T> resultHandler) {
+        public DefaultCallback(Action<T> clientRequest, final HttpRequest request, JestResultHandler<? super T> resultHandler) {
             this.clientRequest = clientRequest;
+            this.request = request;
             this.resultHandler = resultHandler;
         }
 
@@ -173,8 +191,8 @@ public class JestHttpClient extends AbstractJestClient {
         public void completed(final HttpResponse response) {
             T jestResult = null;
             try {
-                jestResult = deserializeResponse(response, clientRequest);
-            } catch (Exception e) {
+                jestResult = deserializeResponse(response, request, clientRequest);
+            } catch (IOException e) {
                 failed(e);
             }
             if (jestResult != null) resultHandler.completed(jestResult);

--- a/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
+++ b/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
@@ -1,0 +1,81 @@
+package io.searchbox.client.http;
+
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+
+import org.littleshoot.proxy.HttpFilters;
+import org.littleshoot.proxy.HttpFiltersAdapter;
+import org.littleshoot.proxy.HttpFiltersSourceAdapter;
+import org.littleshoot.proxy.HttpProxyServer;
+import org.littleshoot.proxy.HttpProxyServerBootstrap;
+import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.handler.codec.http.DefaultFullHttpResponse;
+import io.netty.handler.codec.http.HttpObject;
+import io.netty.handler.codec.http.HttpRequest;
+import io.netty.handler.codec.http.HttpResponse;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.netty.handler.codec.http.HttpVersion;
+
+public class FailingProxy {
+    public static final int PROXY_PORT = 54321;
+
+    private final HttpProxyServer server;
+
+    public FailingProxy() {
+        final HttpProxyServerBootstrap bootstrap = DefaultHttpProxyServer
+                .bootstrap()
+                .withPort(PROXY_PORT)
+                .withTransparent(true)
+                .withFiltersSource(new FailingSourceAdapter())
+                ;
+        server = bootstrap.start();
+    }
+
+    public String getUrl() {
+        final InetSocketAddress listenAddress = server.getListenAddress();
+        final String host = listenAddress.getHostName();
+        final int port = listenAddress.getPort();
+        return String.format("http://%s:%d/", host, port);
+    }
+
+    public void stop() {
+        server.stop();
+    }
+
+    private static class FailingSourceAdapter extends HttpFiltersSourceAdapter {
+        @Override
+        public HttpFilters filterRequest(final HttpRequest originalRequest) {
+            return new FailingFilterAdapter(originalRequest);
+        }
+    }
+
+    private static class FailingFilterAdapter extends HttpFiltersAdapter {
+
+        public FailingFilterAdapter(final HttpRequest originalRequest) {
+            super(originalRequest);
+        }
+
+        @Override
+        public HttpResponse requestPre(final HttpObject httpObject) {
+
+            final HttpResponseStatus status = new HttpResponseStatus(500, "This proxy always fails");
+
+            final String message = "<html>"
+                    + "  <head><title>This proxy always fails</title></head>"
+                    + "<body>"
+                    + "  <h1>This proxy always fails</h1>"
+                    + "</body>"
+                    + "</html>";
+            ByteBuf buf = Unpooled.wrappedBuffer(message.getBytes(Charset.forName("UTF-8")));
+
+            final DefaultFullHttpResponse response = new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, status, buf);
+            response.headers().set("Content-Type", "text/html");
+
+            return response;
+        }
+    }
+
+}

--- a/jest/src/test/java/io/searchbox/client/http/FailingProxyTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/FailingProxyTest.java
@@ -1,0 +1,98 @@
+package io.searchbox.client.http;
+
+import java.io.IOException;
+import java.util.concurrent.Semaphore;
+
+import org.hamcrest.Matchers;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import io.searchbox.client.JestClientFactory;
+import io.searchbox.client.JestResult;
+import io.searchbox.client.JestResultHandler;
+import io.searchbox.client.config.HttpClientConfig;
+import io.searchbox.indices.Stats;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.junit.Assert.assertThat;
+
+/** Test the situation where there's a misconfigured proxy between the Jest
+ * client and the server.  If the proxy speaks text/html instead of
+ * application/json, we should not throw a generic JsonSyntaxException.
+ */
+public class FailingProxyTest {
+    JestClientFactory factory = new JestClientFactory();
+    private FailingProxy proxy;
+    private JestHttpClient client;
+    private Stats status;
+
+    @Before
+    public void setUp() throws IOException {
+        proxy = new FailingProxy();
+
+        String url = proxy.getUrl();
+        factory.setHttpClientConfig(new HttpClientConfig.Builder(url).build());
+        client = (JestHttpClient) factory.getObject();
+        assertThat(client, is(not(nullValue())));
+
+        status = new Stats.Builder().build();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        client.shutdownClient();
+        proxy.stop();
+    }
+
+    @Test
+    public void testWithFailingProxy() throws InterruptedException, IOException {
+        Exception exception = null;
+        try {
+            final JestResult result = client.execute(status);
+        } catch (Exception e) {
+            exception = e;
+        }
+        validateException(exception);
+    }
+
+    @Test
+    public void testAsyncWithFailingProxy() throws InterruptedException, IOException {
+        final ResultHandler resultHandler = new ResultHandler();
+        client.executeAsync(status, resultHandler);
+        Exception exception = resultHandler.get();
+        validateException(exception);
+    }
+
+    private void validateException(final Exception e) {
+        assertThat(e, is(not(Matchers.nullValue())));
+        final String message = e.toString();
+        assertThat(message, not(containsString("Use JsonReader.setLenient(true)")));
+        assertThat(message, containsString("text/html"));
+        assertThat(message, containsString("should be json"));
+    }
+
+    private class ResultHandler implements JestResultHandler {
+        private final Semaphore sema = new Semaphore(0);
+        private Exception exception = null;
+
+        @Override
+        public void completed(final Object result) {
+            sema.release();
+        }
+
+        @Override
+        public void failed(final Exception ex) {
+            exception = ex;
+            sema.release();
+        }
+
+        public Exception get() throws InterruptedException {
+            sema.acquire();
+            return exception;
+        }
+    }
+}


### PR DESCRIPTION
If there's a proxy between you and the server, and that proxy encounters a problem, the http response will usually be text/html, not application/json. 

Without the patch, this gives 
```
com.google.gson.JsonSyntaxException: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 4 path $
	at com.google.gson.JsonParser.parse(JsonParser.java:65)
	at com.google.gson.JsonParser.parse(JsonParser.java:45)
	at io.searchbox.action.AbstractAction.parseResponseBody(AbstractAction.java:94)
	at io.searchbox.action.AbstractAction.createNewElasticSearchResult(AbstractAction.java:65)
	at io.searchbox.action.GenericResultAbstractAction.createNewElasticSearchResult(GenericResultAbstractAction.java:20)
	at io.searchbox.client.http.JestHttpClient.deserializeResponse(JestHttpClient.java:131)
	at io.searchbox.client.http.JestHttpClient.access$000(JestHttpClient.java:32)
	at io.searchbox.client.http.JestHttpClient$DefaultCallback.completed(JestHttpClient.java:176)
	at io.searchbox.client.http.JestHttpClient$DefaultCallback.completed(JestHttpClient.java:163)
	at org.apache.http.concurrent.BasicFuture.completed(BasicFuture.java:119)
	at org.apache.http.impl.nio.client.DefaultClientExchangeHandlerImpl.responseCompleted(DefaultClientExchangeHandlerImpl.java:177)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.processResponse(HttpAsyncRequestExecutor.java:412)
	at org.apache.http.nio.protocol.HttpAsyncRequestExecutor.inputReady(HttpAsyncRequestExecutor.java:305)
	at org.apache.http.impl.nio.DefaultNHttpClientConnection.consumeInput(DefaultNHttpClientConnection.java:267)
	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:81)
	at org.apache.http.impl.nio.client.InternalIODispatch.onInputReady(InternalIODispatch.java:39)
	at org.apache.http.impl.nio.reactor.AbstractIODispatch.inputReady(AbstractIODispatch.java:116)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.readable(BaseIOReactor.java:164)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvent(AbstractIOReactor.java:339)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.processEvents(AbstractIOReactor.java:317)
	at org.apache.http.impl.nio.reactor.AbstractIOReactor.execute(AbstractIOReactor.java:278)
	at org.apache.http.impl.nio.reactor.BaseIOReactor.execute(BaseIOReactor.java:106)
	at org.apache.http.impl.nio.reactor.AbstractMultiworkerIOReactor$Worker.run(AbstractMultiworkerIOReactor.java:590)
	at java.lang.Thread.run(Thread.java:745)
Caused by: com.google.gson.stream.MalformedJsonException: Use JsonReader.setLenient(true) to accept malformed JSON at line 2 column 4 path $
	at com.google.gson.stream.JsonReader.syntaxError(JsonReader.java:1573)
	at com.google.gson.stream.JsonReader.checkLenient(JsonReader.java:1423)
	at com.google.gson.stream.JsonReader.doPeek(JsonReader.java:546)
	at com.google.gson.stream.JsonReader.peek(JsonReader.java:429)
	at com.google.gson.JsonParser.parse(JsonParser.java:60)
	... 23 more
```

With the patch, it says
```
java.io.IOException: Request GET http://127.0.0.1:51091//_all/_status HTTP/1.1 yielded text/html, should be json: HTTP/1.0 500 This proxy always fails
	at io.searchbox.client.http.JestHttpClient.deserializeResponse(JestHttpClient.java:147)
        ...
```