### PR TITLE
serverList printing function added.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -97,4 +97,8 @@ public abstract class AbstractJestClient implements JestClient {
         this.requestCompressionEnabled = requestCompressionEnabled;
     }
 
+    public Pair<Integer, Iterator<String>> getServerPoolReferencePair() {
+        return serverPoolReference.get();
+    }
+
 }

--- a/jest-common/src/test/java/io/searchbox/client/AbstractJestClientTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/AbstractJestClientTest.java
@@ -1,10 +1,12 @@
 package io.searchbox.client;
 
 import io.searchbox.action.Action;
+import org.apache.commons.lang3.tuple.Pair;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 
@@ -39,21 +41,54 @@ public class AbstractJestClientTest {
     @Test
     public void testGetElasticSearchServer() throws Exception {
         LinkedHashSet<String> set = new LinkedHashSet<String>();
-        set.add("http://localhost:9200");
-        set.add("http://localhost:9300");
-        set.add("http://localhost:9400");
+
+        String node1 = "http://localhost:9200";
+        String node2 = "http://localhost:9300";
+        String node3 = "http://localhost:9400";
+
+        set.add(node1);
+        set.add(node2);
+        set.add(node3);
         client.setServers(set);
 
         Set<String> serverList = new HashSet<String>();
-
         for (int i = 0; i < 3; i++) {
             serverList.add(client.getNextServer());
         }
 
         assertEquals("round robin does not work", 3, serverList.size());
 
-        assertTrue(set.contains("http://localhost:9200"));
-        assertTrue(set.contains("http://localhost:9300"));
-        assertTrue(set.contains("http://localhost:9400"));
+        assertTrue(set.contains(node1));
+        assertTrue(set.contains(node2));
+        assertTrue(set.contains(node3));
     }
+
+    @Test
+    public void testServerPoolReferencePair() throws Exception {
+        LinkedHashSet<String> set = new LinkedHashSet<String>();
+
+        String node1 = "http://localhost:9200";
+        String node2 = "http://localhost:9300";
+        String node3 = "http://localhost:9400";
+
+        set.add(node1);
+        set.add(node2);
+        set.add(node3);
+        client.setServers(set);
+
+        Pair<Integer, Iterator<String>> serverPoolReference = client.getServerPoolReferencePair();
+
+        Set<String> serverList = new HashSet<String>();
+
+        for (int i = 0; i < serverPoolReference.getKey(); i++) {
+            serverList.add(serverPoolReference.getValue().next());
+        }
+
+        assertEquals("could not print serverList", 3, serverList.size());
+
+        assertTrue(set.contains(node1));
+        assertTrue(set.contains(node2));
+        assertTrue(set.contains(node3));
+    }
+
 }


### PR DESCRIPTION
Hello
I want to update Jest Client version to 1.0.0 from 0.1.5 .
In my case of legacy codes, I was printing the round robin serverList for debugging.
the code is below.
```java
private final JestHttpClient client;
	
if (LOGGER.isInfoEnabled()) {
	LOGGER.info(" Uri - {} / {}", clientRequest.getRestMethodName(), LazyStringBuilder.create(client.getServers()), clientRequest.getURI());

	Gson gson = new GsonBuilder().create();

	Object data = clientRequest.getData(gson);
	LOGGER.info(" request data - {} ", data);
}		
```
I has been updated to 1.0.0.
After that,  I could not use client.getServers() method.
It looks like removed.
In my opinion, 
we want to know requested server list.
It's convenient If we can see them.

Changes.
1. added getter to access for serverList
2. refactoring testCase code, testGetElasticSearchServer