### PR TITLE
add ability to search with inline or stored template

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Search.java
+++ b/jest-common/src/main/java/io/searchbox/core/Search.java
@@ -1,11 +1,13 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
+
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
 import io.searchbox.core.search.sort.Sort;
 import io.searchbox.params.Parameters;
 import io.searchbox.params.SearchType;
+
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
@@ -26,6 +28,15 @@ public class Search extends AbstractAction<SearchResult> {
         this.query = builder.query;
         this.sortList = builder.sortList;
         setURI(buildURI());
+    }
+    
+    protected Search(TemplateBuilder templatedBuilder) {
+        super(templatedBuilder);
+
+        //reuse query as it's just the request body of the POST
+        this.query = templatedBuilder.query;
+        this.sortList = templatedBuilder.sortList;
+        setURI(buildURI() + "/template");
     }
 
     @Override
@@ -68,7 +79,7 @@ public class Search extends AbstractAction<SearchResult> {
                 sortMaps.add(sort.toMap());
             }
 
-            Map rootJson = gson.fromJson(query, Map.class);
+            Map<String, List<Map<String, Object>>> rootJson = gson.fromJson(query, Map.class);
             rootJson.put("sort", sortMaps);
             data = gson.toJson(rootJson);
         }
@@ -104,8 +115,12 @@ public class Search extends AbstractAction<SearchResult> {
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<Search, Builder> {
-        private String query;
-        private List<Sort> sortList = new LinkedList<Sort>();
+        protected String query;
+        protected List<Sort> sortList = new LinkedList<Sort>();
+        
+        protected Builder() {
+        	
+        }
 
         public Builder(String query) {
             this.query = query;
@@ -126,6 +141,17 @@ public class Search extends AbstractAction<SearchResult> {
         }
 
         @Override
+        public Search build() {
+            return new Search(this);
+        }
+    }
+    
+    public static class TemplateBuilder extends Builder {    	
+    	public TemplateBuilder(String templatedQuery) {    		
+            super.query = templatedQuery;
+        }
+    	
+    	@Override
         public Search build() {
             return new Search(this);
         }

--- a/jest-common/src/test/java/io/searchbox/core/SearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchTest.java
@@ -1,15 +1,22 @@
 package io.searchbox.core;
 
-import com.google.gson.*;
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertNotEquals;
 import io.searchbox.action.Action;
 import io.searchbox.core.search.sort.Sort;
 import io.searchbox.core.search.sort.Sort.Sorting;
-import org.junit.Test;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.*;
-import static org.junit.Assert.assertNotEquals;
+import org.junit.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 /**
  * @author Dogukan Sonmez
@@ -67,6 +74,18 @@ public class SearchTest {
                 .addType("jest")
                 .build();
         assertEquals("twitter%2Csearchbox/tweet%2Cjest/_search", search.getURI());
+    }
+    
+    @Test
+    public void getURIForTemplateWithoutIndexAndType() {
+        Action search = new Search.TemplateBuilder("").build();
+        assertEquals("_all/_search/template", search.getURI());
+    }
+    
+    @Test
+    public void getURIForTemplateWithIndexAndType() {
+        Action search = new Search.TemplateBuilder("").addIndex("twitter").addType("tweet").build();
+        assertEquals("twitter/tweet/_search/template", search.getURI());
     }
 
     @Test


### PR DESCRIPTION
Added ability to search with templates (inline or stored) resolving #240 

Currently master only. I guess I merge this to the 1.x line as well if needed.