### PR TITLE
Use daemon threads for NodeChecker and IdleConnectionReaper.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -114,7 +114,7 @@ public class NodeChecker extends AbstractScheduledService {
             }
             @Override public void failed(State from, Throwable failure) {
                 executor.shutdown();
-            }}, MoreExecutors.sameThreadExecutor());
+            }}, MoreExecutors.directExecutor());
         return executor;
     }
 

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -1,6 +1,8 @@
 package io.searchbox.client.config.discovery;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import io.searchbox.client.JestClient;
@@ -11,6 +13,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
@@ -89,6 +94,28 @@ public class NodeChecker extends AbstractScheduledService {
     @Override
     protected Scheduler scheduler() {
         return scheduler;
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+        final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat(serviceName())
+                .build());
+        // Add a listener to shutdown the executor after the service is stopped.  This ensures that the
+        // JVM shutdown will not be prevented from exiting after this service has stopped or failed.
+        // Technically this listener is added after start() was called so it is a little gross, but it
+        // is called within doStart() so we know that the service cannot terminate or fail concurrently
+        // with adding this listener so it is impossible to miss an event that we are interested in.
+        addListener(new Listener() {
+            @Override public void terminated(State from) {
+                executor.shutdown();
+            }
+            @Override public void failed(State from, Throwable failure) {
+                executor.shutdown();
+            }}, MoreExecutors.sameThreadExecutor());
+        return executor;
     }
 
     /**

--- a/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
@@ -1,9 +1,15 @@
 package io.searchbox.client.config.idle;
 
 import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.searchbox.client.config.ClientConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
 
 /**
  * Used to reap idle connections from the connection manager.
@@ -32,5 +38,27 @@ public class IdleConnectionReaper extends AbstractScheduledService {
         return Scheduler.newFixedDelaySchedule(0l,
                                                clientConfig.getMaxConnectionIdleTime(),
                                                clientConfig.getMaxConnectionIdleTimeDurationTimeUnit());
+    }
+
+    @Override
+    protected ScheduledExecutorService executor() {
+        final ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor(
+            new ThreadFactoryBuilder()
+                .setDaemon(true)
+                .setNameFormat(serviceName())
+                .build());
+        // Add a listener to shutdown the executor after the service is stopped.  This ensures that the
+        // JVM shutdown will not be prevented from exiting after this service has stopped or failed.
+        // Technically this listener is added after start() was called so it is a little gross, but it
+        // is called within doStart() so we know that the service cannot terminate or fail concurrently
+        // with adding this listener so it is impossible to miss an event that we are interested in.
+        addListener(new Listener() {
+            @Override public void terminated(State from) {
+                executor.shutdown();
+            }
+            @Override public void failed(State from, Throwable failure) {
+                executor.shutdown();
+            }}, MoreExecutors.sameThreadExecutor());
+        return executor;
     }
 }

--- a/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/idle/IdleConnectionReaper.java
@@ -58,7 +58,7 @@ public class IdleConnectionReaper extends AbstractScheduledService {
             }
             @Override public void failed(State from, Throwable failure) {
                 executor.shutdown();
-            }}, MoreExecutors.sameThreadExecutor());
+            }}, MoreExecutors.directExecutor());
         return executor;
     }
 }


### PR DESCRIPTION
Resolve #278 by using daemon threads in NodeChecker and IdleConnectionReaper.