### PR TITLE
NodeChecker factory method added to JestClientFactory - fixes #312

### DIFF
--- a/jest/src/main/java/io/searchbox/client/JestClientFactory.java
+++ b/jest/src/main/java/io/searchbox/client/JestClientFactory.java
@@ -67,7 +67,7 @@ public class JestClientFactory {
         // set discovery (should be set after setting the httpClient on jestClient)
         if (httpClientConfig.isDiscoveryEnabled()) {
             log.info("Node Discovery enabled...");
-            NodeChecker nodeChecker = new NodeChecker(client, httpClientConfig);
+            NodeChecker nodeChecker = createNodeChecker(client, httpClientConfig);
             client.setNodeChecker(nodeChecker);
             nodeChecker.startAsync();
             nodeChecker.awaitRunning();
@@ -226,4 +226,10 @@ public class JestClientFactory {
 
         return retval;
     }
+
+    // Extension point
+    protected NodeChecker createNodeChecker(JestHttpClient client, HttpClientConfig httpClientConfig) {
+        return new NodeChecker(client, httpClientConfig);
+    }
+
 }


### PR DESCRIPTION
Extension point was added to JestClientFactory. It makes NodeChecker object's creation overridable, hence configurable. Replacing default NodeChecker with custom implementation will increase Jest capabilities, e.g.:
- customizing any feature of the current NodeChecker - it has protected methods, but JestClientFactory forbids to replace it
- replacing discovery mechanism with other than one based purely on ElasticSearch API