### PR TITLE
HTTPS / SSL README Fixes

### DIFF
--- a/jest/README.md
+++ b/jest/README.md
@@ -511,6 +511,7 @@ SchemeIOSessionStrategy httpsIOSessionStrategy = new SSLIOSessionStrategy(sslCon
 
 JestClientFactory factory = new JestClientFactory();
 factory.setHttpClientConfig(new HttpClientConfig.Builder("https://localhost:9200")
+                .defaultSchemeForDiscoveredNodes("https") // required, otherwise uses http
                 .sslSocketFactory(sslSocketFactory) // this only affects sync calls
                 .httpsIOSessionStrategy(httpsIOSessionStrategy) // this only affects async calls
                 .build()


### PR DESCRIPTION
## Description
Near as I can tell, the `defaultSchemeForDiscoveredNodes` property is _required_ to be set if you plan on using SSL at all; otherwise it defaults to `http` and nothing will work.

## Question
I was _going_ to add some information that indicates that *not* verifying the certificate is the only thing that Jest can do at this point since it _appears_ as though it would never be able to use anything other than an IP address; is this true? I only ask because I cannot for the life of me figure out how to get Jest to use the DNS name rather than the IP address as mentioned in #270. Please advise.