### PR TITLE
Fix NPE when bulk item result has "_id":null

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/BulkResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/BulkResult.java
@@ -93,7 +93,7 @@ public class BulkResult extends JestResult {
             this.operation = operation;
             this.index = values.get("_index").getAsString();
             this.type = values.get("_type").getAsString();
-            this.id = values.get("_id").getAsString();
+            this.id = values.has("_id") && !values.get("_id").isJsonNull() ? values.get("_id").getAsString() : null;
             this.status = values.get("status").getAsInt();
             this.error = values.has("error") ? values.get("error").toString() : null;
         }

--- a/jest-common/src/test/java/io/searchbox/core/BulkResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/BulkResultTest.java
@@ -1,0 +1,40 @@
+package io.searchbox.core;
+
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+
+public class BulkResultTest {
+
+    static String indexFailedResult = "{\n" +
+            "    \"took\": 10,\n" +
+            "    \"errors\": true,\n" +
+            "    \"items\": [\n" +
+            "        {\n" +
+            "            \"index\": {\n" +
+            "                \"_index\": \"index-name\",\n" +
+            "                \"_type\": \"type-name\",\n" +
+            "                \"_id\": null,\n" +
+            "                \"status\": 400,\n" +
+            "                \"error\": \"MapperParsingException[mapping [type-name]]; nested: MapperParsingException[No type specified for property [field-name]]; \"\n" +
+            "            }\n" +
+            "        }\n" +
+            "    ]\n" +
+            "}";
+
+    @Test
+    public void bulkResultWithFailures() {
+        BulkResult bulkResult = new BulkResult(new GsonBuilder().serializeNulls().create());
+        bulkResult.setJsonString(indexFailedResult);
+        bulkResult.setJsonMap(new Gson().fromJson(indexFailedResult, Map.class));
+        bulkResult.setSucceeded(false);
+
+        assertEquals(1, bulkResult.getItems().size());
+        assertEquals(1, bulkResult.getFailedItems().size());
+    }
+}


### PR DESCRIPTION
When an item fails in bulk indexing, trying to getItems() from BulkResult throws NPE.