### PR TITLE
added ClearScroll action

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/ClearScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/ClearScroll.java
@@ -1,0 +1,62 @@
+package io.searchbox.core;
+
+import com.google.common.collect.ImmutableMap;
+import io.searchbox.action.GenericResultAbstractAction;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+
+public class ClearScroll extends GenericResultAbstractAction {
+
+  private final String uri;
+
+  public ClearScroll(Builder builder) {
+
+    if (builder.getScrollIds().size() == 0) {
+      uri = "/_search/scroll/_all";
+      this.payload = null;
+    } else {
+      uri = "/_search/scroll";
+      this.payload = ImmutableMap.of("scroll_id", builder.getScrollIds());
+    }
+
+    setURI(buildURI());
+  }
+
+  @Override
+  public String getRestMethodName() {
+    return "DELETE";
+  }
+
+  @Override
+  protected String buildURI() {
+    return super.buildURI() + uri;
+  }
+
+  public static class Builder extends GenericResultAbstractAction.Builder<ClearScroll, Builder> {
+
+    protected Collection<String> scrollIds = new LinkedHashSet<String>();
+
+    public Builder addScrollId(String scrollId) {
+      this.scrollIds.add(scrollId);
+      return this;
+    }
+
+    public Builder addScrollIds(Set<String> scrollIds) {
+      this.scrollIds.addAll(scrollIds);
+      return this;
+    }
+
+    @Override
+    public ClearScroll build() {
+      return new ClearScroll(this);
+    }
+
+    public Collection<String> getScrollIds() {
+      return scrollIds;
+    }
+
+  }
+}

--- a/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
@@ -1,16 +1,18 @@
 package io.searchbox.core;
 
 import com.google.gson.JsonArray;
-import io.searchbox.client.JestResult;
-import io.searchbox.common.AbstractIntegrationTest;
-import io.searchbox.core.search.sort.Sort;
-import io.searchbox.params.Parameters;
+
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+
+import io.searchbox.client.JestResult;
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.search.sort.Sort;
+import io.searchbox.params.Parameters;
 
 
 /**
@@ -74,7 +76,68 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
                 result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits").size()
         );
 
-        clearScroll(scrollId);
+        // clear a single scroll id
+        ClearScroll clearScroll = new ClearScroll.Builder().addScrollId(scrollId).build();
+        result = client.execute(clearScroll);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+    }
+
+    @Test
+    public void clearScrollAll() throws IOException {
+        assertTrue(index(INDEX, TYPE, "swvq1", "{\"code\":\"0\"}").isCreated());
+        assertTrue(index(INDEX, TYPE, "swvq2", "{\"code\":\"1\"}").isCreated());
+        assertTrue(index(INDEX, TYPE, "swvq3", "{\"code\":\"2\"}").isCreated());
+        refresh();
+        ensureSearchable(INDEX);
+
+        SearchSourceBuilder searchSourceBuilder = new SearchSourceBuilder();
+        searchSourceBuilder.query(QueryBuilders.matchAllQuery());
+
+        Search search = new Search.Builder(searchSourceBuilder.toString())
+            .addIndex(INDEX)
+            .addType(TYPE)
+            .addSort(new Sort("code"))
+            .setParameter(Parameters.SIZE, 1)
+            .setParameter(Parameters.SCROLL, "5m")
+            .build();
+        JestResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        JsonArray hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
+        assertEquals(
+            "only 1 document should be returned",
+            1,
+            hits.size()
+        );
+
+        String scrollId = result.getJsonObject().get("_scroll_id").getAsString();
+        for (int i = 1; i < 3; i++) {
+            SearchScroll scroll = new SearchScroll.Builder(scrollId, "5m")
+                .setParameter(Parameters.SIZE, 1).build();
+            result = client.execute(scroll);
+            assertTrue(result.getErrorMessage(), result.isSucceeded());
+            assertEquals("{\"code\":\"" + i + "\"}", result.getSourceAsString());
+            hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
+            assertEquals(
+                "only 1 document should be returned",
+                1,
+                hits.size()
+            );
+            scrollId = result.getJsonObject().getAsJsonPrimitive("_scroll_id").getAsString();
+        }
+
+        SearchScroll scroll = new SearchScroll.Builder(scrollId, "5m").build();
+        result = client.execute(scroll);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertEquals(
+            "no results should be left to scroll at this point",
+            0,
+            result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits").size()
+        );
+
+        // clear all scroll ids
+        ClearScroll clearScroll = new ClearScroll.Builder().build();
+        result = client.execute(clearScroll);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
     }
 
 }


### PR DESCRIPTION
see https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html#_clear_scroll_api

I'm working on jest support for spring-data-elasticsearch. The jest API misses this elasticsearch action, see https://github.com/spring-projects/spring-data-elasticsearch/blob/master/src/main/java/org/springframework/data/elasticsearch/core/ElasticsearchOperations.java#L562 