### PR TITLE
NodeChecker remove failed nodes

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -60,6 +60,16 @@
             <artifactId>gson</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpcore-nio</artifactId>
+        </dependency>
+        
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+
         <!-- Testing Dependencies -->
         <dependency>
             <groupId>junit</groupId>

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -44,7 +44,7 @@ public class NodeChecker extends AbstractScheduledService {
     protected Scheduler scheduler;
     protected String defaultScheme;
     protected Set<String> bootstrapServerList;
-  protected Set<String> discoveredServerList;
+    protected Set<String> discoveredServerList;
 
     public NodeChecker(JestClient jestClient, ClientConfig clientConfig) {
         this(jestClient, clientConfig.getDefaultSchemeForDiscoveredNodes(), clientConfig.getDiscoveryFrequency(), clientConfig.getDiscoveryFrequencyTimeUnit(),
@@ -67,20 +67,20 @@ public class NodeChecker extends AbstractScheduledService {
         JestResult result;
         try {
             result = client.execute(action);
-    } catch (HttpHostConnectException e) {
-      // Can't connect to this node, remove it from the list
-      log.error("Connect exception executing NodesInfo!", e);
-      removeNodeAndUpdateServers(e.getHost());
-      return;
-      // do not elevate the exception since that will stop the scheduled calls.
-      // throw new RuntimeException("Error executing NodesInfo!", e);
-    } catch (Exception e) {
-      log.error("Error executing NodesInfo!", e);
-      client.setServers(bootstrapServerList);
-      return;
-      // do not elevate the exception since that will stop the scheduled calls.
-      // throw new RuntimeException("Error executing NodesInfo!", e);
-    }
+        } catch (HttpHostConnectException e) {
+            // Can't connect to this node, remove it from the list
+            log.error("Connect exception executing NodesInfo!", e);
+            removeNodeAndUpdateServers(e.getHost());
+            return;
+            // do not elevate the exception since that will stop the scheduled calls.
+            // throw new RuntimeException("Error executing NodesInfo!", e);
+        } catch (Exception e) {
+            log.error("Error executing NodesInfo!", e);
+            client.setServers(bootstrapServerList);
+            return;
+            // do not elevate the exception since that will stop the scheduled calls.
+            // throw new RuntimeException("Error executing NodesInfo!", e);
+        }  
 
         if (result.isSucceeded()) {
             LinkedHashSet<String> httpHosts = new LinkedHashSet<String>();
@@ -104,22 +104,22 @@ public class NodeChecker extends AbstractScheduledService {
             if (log.isDebugEnabled()) {
                 log.debug("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ","));
             }
-      discoveredServerList = httpHosts;
-      client.setServers(discoveredServerList);
+            discoveredServerList = httpHosts;
+            client.setServers(discoveredServerList);
         } else {
             log.warn("NodesInfo request resulted in error: {}", result.getErrorMessage());
             client.setServers(bootstrapServerList);
         }
     }
 
-  private void removeNodeAndUpdateServers(final HttpHost hostToRemove) {
-    discoveredServerList.remove(hostToRemove.toURI());
-    if (!discoveredServerList.isEmpty()) {
-      client.setServers(discoveredServerList);
-    } else {
-      client.setServers(bootstrapServerList);
+    private void removeNodeAndUpdateServers(final HttpHost hostToRemove) {
+        discoveredServerList.remove(hostToRemove.toURI());
+        if (!discoveredServerList.isEmpty()) {
+          client.setServers(discoveredServerList);
+        } else {
+          client.setServers(bootstrapServerList);
+        }
     }
-  }
 
     @Override
     protected Scheduler scheduler() {

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -6,20 +6,23 @@ import com.google.common.util.concurrent.MoreExecutors;
 import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.config.ClientConfig;
 import io.searchbox.cluster.NodesInfo;
+
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHost;
+import org.apache.http.conn.HttpHostConnectException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadFactory;
 import java.util.LinkedHashSet;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -41,6 +44,7 @@ public class NodeChecker extends AbstractScheduledService {
     protected Scheduler scheduler;
     protected String defaultScheme;
     protected Set<String> bootstrapServerList;
+  protected Set<String> discoveredServerList;
 
     public NodeChecker(JestClient jestClient, ClientConfig clientConfig) {
         this(jestClient, clientConfig.getDefaultSchemeForDiscoveredNodes(), clientConfig.getDiscoveryFrequency(), clientConfig.getDiscoveryFrequencyTimeUnit(),
@@ -63,13 +67,20 @@ public class NodeChecker extends AbstractScheduledService {
         JestResult result;
         try {
             result = client.execute(action);
-        } catch (Exception e) {
-            log.error("Error executing NodesInfo!", e);
-            client.setServers(bootstrapServerList);
-            return;
-            // do not elevate the exception since that will stop the scheduled calls.
-            // throw new RuntimeException("Error executing NodesInfo!", e);
-        }
+    } catch (HttpHostConnectException e) {
+      // Can't connect to this node, remove it from the list
+      log.error("Connect exception executing NodesInfo!", e);
+      removeNodeAndUpdateServers(e.getHost());
+      return;
+      // do not elevate the exception since that will stop the scheduled calls.
+      // throw new RuntimeException("Error executing NodesInfo!", e);
+    } catch (Exception e) {
+      log.error("Error executing NodesInfo!", e);
+      client.setServers(bootstrapServerList);
+      return;
+      // do not elevate the exception since that will stop the scheduled calls.
+      // throw new RuntimeException("Error executing NodesInfo!", e);
+    }
 
         if (result.isSucceeded()) {
             LinkedHashSet<String> httpHosts = new LinkedHashSet<String>();
@@ -93,12 +104,22 @@ public class NodeChecker extends AbstractScheduledService {
             if (log.isDebugEnabled()) {
                 log.debug("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ","));
             }
-            client.setServers(httpHosts);
+      discoveredServerList = httpHosts;
+      client.setServers(discoveredServerList);
         } else {
             log.warn("NodesInfo request resulted in error: {}", result.getErrorMessage());
             client.setServers(bootstrapServerList);
         }
     }
+
+  private void removeNodeAndUpdateServers(final HttpHost hostToRemove) {
+    discoveredServerList.remove(hostToRemove.toURI());
+    if (!discoveredServerList.isEmpty()) {
+      client.setServers(discoveredServerList);
+    } else {
+      client.setServers(bootstrapServerList);
+    }
+  }
 
     @Override
     protected Scheduler scheduler() {

--- a/jest-common/src/test/java/io/searchbox/client/config/discovery/NodeCheckerTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/config/discovery/NodeCheckerTest.java
@@ -1,23 +1,32 @@
 package io.searchbox.client.config.discovery;
 
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
+
 import io.searchbox.action.Action;
 import io.searchbox.client.JestClient;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.config.ClientConfig;
+
+import org.apache.http.HttpHost;
+import org.apache.http.conn.HttpHostConnectException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.net.ConnectException;
+import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
-
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.isA;
-import static org.mockito.Mockito.*;
 
 public class NodeCheckerTest {
 
@@ -240,5 +249,75 @@ public class NodeCheckerTest {
         assertEquals(1, servers.size());
         assertEquals("http://localhost:9200", servers.iterator().next());
     }
+
+
+  @Test
+  public void testNodesInfoExceptionRemovesServerFromList() throws Exception {
+    NodeChecker nodeChecker = new NodeChecker(jestClient, clientConfig);
+
+    JestResult result = new JestResult(new Gson());
+    result.setJsonMap(ImmutableMap.<String, Object>of(
+        "ok", "true",
+        "nodes", ImmutableMap.of(
+            "node1", ImmutableMap.of(
+                "http_address", "inet[/192.168.2.7:9200]"),
+            "node2", ImmutableMap.of(
+                "http_address", "inet[/192.168.2.8:9200]"),
+            "node3", ImmutableMap.of(
+                "http_address", "inet[/192.168.2.9:9200]"))));
+    result.setSucceeded(true);
+    when(jestClient.execute(isA(Action.class))).thenReturn(result);
+    nodeChecker.runOneIteration();
+
+    verify(jestClient).execute(isA(Action.class));
+    ArgumentCaptor<LinkedHashSet> argument = ArgumentCaptor.forClass(LinkedHashSet.class);
+    verify(jestClient).setServers(argument.capture());
+    verify(jestClient).execute(isA(Action.class));
+
+    Set servers = argument.getValue();
+    assertEquals(3, servers.size());
+
+    when(jestClient.execute(isA(Action.class))).thenThrow(new HttpHostConnectException(
+        new ConnectException(), new HttpHost("192.168.2.7", 9200, "http"), null));
+    nodeChecker.runOneIteration();
+
+    verify(jestClient, times(2)).execute(isA(Action.class));
+    verify(jestClient, times(2)).setServers(argument.capture());
+    verifyNoMoreInteractions(jestClient);
+
+    servers = argument.getValue();
+    assertEquals(2, servers.size());
+    Iterator serversItr = servers.iterator();
+    assertEquals("http://192.168.2.8:9200", serversItr.next());
+    assertEquals("http://192.168.2.9:9200", serversItr.next());
+
+    // fail at the 2nd node
+    when(jestClient.execute(isA(Action.class))).thenThrow(new HttpHostConnectException(
+        new ConnectException(), new HttpHost("192.168.2.8", 9200, "http"), null));
+    nodeChecker.runOneIteration();
+
+    verify(jestClient, times(3)).execute(isA(Action.class));
+    verify(jestClient, times(3)).setServers(argument.capture());
+    verifyNoMoreInteractions(jestClient);
+
+    servers = argument.getValue();
+    assertEquals(1, servers.size());
+    serversItr = servers.iterator();
+    assertEquals("http://192.168.2.9:9200", serversItr.next());
+
+    // fail at the last node, fail back to bootstrap
+    when(jestClient.execute(isA(Action.class))).thenThrow(new HttpHostConnectException(
+        new ConnectException(), new HttpHost("192.168.2.9", 9200, "http"), null));
+    nodeChecker.runOneIteration();
+
+    verify(jestClient, times(4)).execute(isA(Action.class));
+    verify(jestClient, times(4)).setServers(argument.capture());
+    verifyNoMoreInteractions(jestClient);
+
+    servers = argument.getValue();
+    assertEquals(1, servers.size());
+    serversItr = servers.iterator();
+    assertEquals("http://localhost:9200", serversItr.next());
+  }
 
 }


### PR DESCRIPTION
Remove nodes that fail due to a connect exception (due to node being down or network issue) in NodeChecker.  This should resolve Issue #345 where a client can become disconnected from the cluster if only it is configured with a single node (regardless of actual number of nodes in the cluster) and that node is unavailable/down when NodeChecker connects it.