### PR TITLE
Add preemptive authentication option

### DIFF
--- a/jest/src/main/java/io/searchbox/client/JestClientFactory.java
+++ b/jest/src/main/java/io/searchbox/client/JestClientFactory.java
@@ -6,13 +6,18 @@ import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.idle.HttpReapableConnectionManager;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
 import io.searchbox.client.http.JestHttpClient;
+import org.apache.http.HttpHost;
+import org.apache.http.client.AuthCache;
 import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.config.Registry;
 import org.apache.http.config.RegistryBuilder;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.conn.routing.HttpRoute;
 import org.apache.http.conn.routing.HttpRoutePlanner;
 import org.apache.http.conn.socket.ConnectionSocketFactory;
+import org.apache.http.impl.auth.BasicScheme;
+import org.apache.http.impl.client.BasicAuthCache;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
@@ -85,6 +90,12 @@ public class JestClientFactory {
             reaper.awaitRunning();
         } else {
             log.info("Idle connection reaping disabled...");
+        }
+
+        HttpHost preemptiveAuthTargetHost = httpClientConfig.getPreemptiveAuthTargetHost();
+        if (preemptiveAuthTargetHost != null) {
+            log.info("Authentication cache set for preemptive authentication");
+            client.setHttpClientContextTemplate(createPreemptiveAuthContext(preemptiveAuthTargetHost));
         }
 
         return client;
@@ -230,6 +241,23 @@ public class JestClientFactory {
     // Extension point
     protected NodeChecker createNodeChecker(JestHttpClient client, HttpClientConfig httpClientConfig) {
         return new NodeChecker(client, httpClientConfig);
+    }
+
+    // Extension point
+    private HttpClientContext createPreemptiveAuthContext(HttpHost targetHost) {
+        HttpClientContext context = HttpClientContext.create();
+        context.setCredentialsProvider(httpClientConfig.getCredentialsProvider());
+        context.setAuthCache(createBasicAuthCache(targetHost));
+
+        return context;
+    }
+
+    private AuthCache createBasicAuthCache(HttpHost targetHost) {
+        AuthCache authCache = new BasicAuthCache();
+        BasicScheme basicAuth = new BasicScheme();
+        authCache.put(targetHost, basicAuth);
+
+        return authCache;
     }
 
 }

--- a/jest/src/main/java/io/searchbox/client/config/HttpClientConfig.java
+++ b/jest/src/main/java/io/searchbox/client/config/HttpClientConfig.java
@@ -39,6 +39,7 @@ public class HttpClientConfig extends ClientConfig {
     private final AuthenticationStrategy proxyAuthenticationStrategy;
     private final SchemeIOSessionStrategy httpIOSessionStrategy;
     private final SchemeIOSessionStrategy httpsIOSessionStrategy;
+    private HttpHost preemptiveAuthTargetHost;
 
     public HttpClientConfig(Builder builder) {
         super(builder);
@@ -52,6 +53,7 @@ public class HttpClientConfig extends ClientConfig {
         this.proxyAuthenticationStrategy = builder.proxyAuthenticationStrategy;
         this.httpIOSessionStrategy = builder.httpIOSessionStrategy;
         this.httpsIOSessionStrategy = builder.httpsIOSessionStrategy;
+        this.preemptiveAuthTargetHost = builder.preemptiveAuthTargetHost;
     }
 
     public Map<HttpRoute, Integer> getMaxTotalConnectionPerRoute() {
@@ -94,6 +96,10 @@ public class HttpClientConfig extends ClientConfig {
         return httpsIOSessionStrategy;
     }
 
+    public HttpHost getPreemptiveAuthTargetHost() {
+        return preemptiveAuthTargetHost;
+    }
+
     public static class Builder extends ClientConfig.AbstractBuilder<HttpClientConfig, Builder> {
 
         private Integer maxTotalConnection;
@@ -106,6 +112,7 @@ public class HttpClientConfig extends ClientConfig {
         private AuthenticationStrategy proxyAuthenticationStrategy;
         private SchemeIOSessionStrategy httpIOSessionStrategy;
         private SchemeIOSessionStrategy httpsIOSessionStrategy;
+        private HttpHost preemptiveAuthTargetHost;
 
         public Builder(HttpClientConfig httpClientConfig) {
             super(httpClientConfig);
@@ -231,6 +238,19 @@ public class HttpClientConfig extends ClientConfig {
             return this;
         }
 
+        /**
+         * Sets preemptive authentication for the specified <b>target host</b> by pre-populating an authentication data cache
+         * <p>
+         * It is mandatory to set a credential provider to use preemptive authentication
+         * </p><p>
+         * If preemptive authentication is set without setting a credentials provider an exception will be thrown
+         * </p>
+         */
+        public Builder setPreemptiveAuth(HttpHost targetHost) {
+            this.preemptiveAuthTargetHost = targetHost;
+            return this;
+        }
+
         public Builder proxy(HttpHost proxy) {
             return proxy(proxy, null);
         }
@@ -258,7 +278,16 @@ public class HttpClientConfig extends ClientConfig {
             if(this.httpsIOSessionStrategy == null) {
                 this.httpsIOSessionStrategy = SSLIOSessionStrategy.getSystemDefaultStrategy();
             }
+
+            if (preemptiveAuthSetWithoutCredentials()) {
+                throw new IllegalArgumentException("Preemptive authentication set without credentials provider");
+            }
+
             return new HttpClientConfig(this);
+        }
+
+        private boolean preemptiveAuthSetWithoutCredentials() {
+            return preemptiveAuthTargetHost != null && credentialsProvider == null;
         }
 
     }

--- a/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
+++ b/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
@@ -1,5 +1,6 @@
 package io.searchbox.client.config;
 
+import org.apache.http.HttpHost;
 import org.apache.http.auth.AuthScope;
 import org.apache.http.auth.Credentials;
 import org.apache.http.client.CredentialsProvider;
@@ -8,6 +9,7 @@ import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 /**
  * @author cihat keser
@@ -48,6 +50,28 @@ public class HttpClientConfigTest {
                 .build();
 
         assertEquals(customCredentialsProvider, httpClientConfig.getCredentialsProvider());
+    }
+
+    @Test
+    public void preemptiveAuth() {
+        String hostName = "targetHost";
+        int port = 80;
+
+        HttpClientConfig httpClientConfig = new HttpClientConfig.Builder("localhost")
+                .defaultCredentials("someUser", "somePassword")
+                .setPreemptiveAuth(new HttpHost(hostName, port, "http"))
+                .build();
+
+        assertEquals(hostName, httpClientConfig.getPreemptiveAuthTargetHost().getHostName());
+        assertEquals(port, httpClientConfig.getPreemptiveAuthTargetHost().getPort());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void preemptiveAuthWithoutCredentials() {
+        new HttpClientConfig.Builder("localhost")
+                .setPreemptiveAuth(new HttpHost("localhost", 80, "http"))
+                .build();
+        fail("Builder should have thrown an exception if preemptive authentication is set without setting credentials");
     }
 
 }

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
@@ -7,8 +7,11 @@ import io.searchbox.client.http.apache.HttpGetWithEntity;
 import io.searchbox.core.Search;
 import org.apache.http.Header;
 import org.apache.http.HttpVersion;
+import org.apache.http.client.AuthCache;
+import org.apache.http.client.CredentialsProvider;
 import org.apache.http.client.entity.GzipCompressingEntity;
 import org.apache.http.client.methods.*;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.After;
@@ -20,6 +23,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 
 import static junit.framework.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.argThat;
@@ -156,6 +161,24 @@ public class JestHttpClientTest {
                 return retval;
             }
         }));
+    }
+
+    @Test
+    public void createContextInstanceWithPreemptiveAuth() {
+        AuthCache authCacheMock = mock(AuthCache.class);
+        CredentialsProvider credentialsProviderMock = mock(CredentialsProvider.class);
+
+        HttpClientContext httpClientContextTemplate = HttpClientContext.create();
+        httpClientContextTemplate.setAuthCache(authCacheMock);
+        httpClientContextTemplate.setCredentialsProvider(credentialsProviderMock);
+
+        JestHttpClient jestHttpClient = (JestHttpClient) new JestClientFactory().getObject();
+        jestHttpClient.setHttpClientContextTemplate(httpClientContextTemplate);
+
+        HttpClientContext httpClientContextResult = jestHttpClient.createContextInstance();
+
+        assertEquals(authCacheMock, httpClientContextResult.getAuthCache());
+        assertEquals(credentialsProviderMock, httpClientContextResult.getCredentialsProvider());
     }
 
 }


### PR DESCRIPTION
- Resolves issue #207 
- Adds the option to set preemptive authentication to a target host by pre-populating the authentication data cache through the http client context, which will be sent in every request execution.
- As the http client context object is not thread safe, a new instance will be created for each execution.
- Setting the credentials provider is mandatory in order to set preemptive authentication, so as described in the new http config builder method javadoc, an exception will be thrown if this option is set without providing credentials