### PR TITLE
Create reindex API implementation

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Reindex.java
+++ b/jest-common/src/main/java/io/searchbox/core/Reindex.java
@@ -1,7 +1,6 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
-import com.sun.javaws.exceptions.InvalidArgumentException;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.client.JestResult;
 
@@ -65,11 +64,9 @@ public class Reindex extends AbstractAction<JestResult> {
         }
 
         @SuppressWarnings("unchecked")
-        public Builder versionType(String vt) throws InvalidArgumentException {
+        public Builder versionType(String vt) throws Exception {
             if(vt == null || vt.equals("")) {
-                String[] arg = new String[1];
-                arg[0] = "version type can't be empty";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("version type can't be empty");
             }
 
             ((Map<String, Object>)source.get("dest")).put("version_type", vt);
@@ -77,11 +74,9 @@ public class Reindex extends AbstractAction<JestResult> {
         }
 
         @SuppressWarnings("unchecked")
-        public Builder operationType(String op) throws InvalidArgumentException {
+        public Builder operationType(String op) throws Exception {
             if(op == null || op.equals("")) {
-                String[] arg = new String[1];
-                arg[0] = "operation type can't be empty";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("operation type can't be empty");
             }
 
             ((Map<String, Object>)source.get("dest")).put("op_type", op);
@@ -89,11 +84,9 @@ public class Reindex extends AbstractAction<JestResult> {
         }
 
         @SuppressWarnings("unchecked")
-        public Builder srcDocumentType(String doc_type) throws InvalidArgumentException {
+        public Builder srcDocumentType(String doc_type) throws Exception {
             if(doc_type == null || doc_type.equals("")) {
-                String[] arg = new String[1];
-                arg[0] = "document type can't be empty";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("document type can't be empty");
             }
 
             ((Map<String, Object>)source.get("source")).put("type", doc_type);
@@ -101,11 +94,9 @@ public class Reindex extends AbstractAction<JestResult> {
         }
 
         @SuppressWarnings("unchecked")
-        public Builder srcDocumentType(String[] doc_types) throws InvalidArgumentException {
+        public Builder srcDocumentType(String[] doc_types) throws Exception {
             if(doc_types == null || doc_types.length == 0) {
-                String[] arg = new String[1];
-                arg[0] = "document type can't be empty";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("document type can't be empty");
             }
 
             ((Map<String, Object>)source.get("source")).put("type", doc_types);
@@ -120,11 +111,9 @@ public class Reindex extends AbstractAction<JestResult> {
             return this;
         }
 
-        public Builder size(int s) throws InvalidArgumentException {
+        public Builder size(int s) throws Exception {
             if(s <= 0) {
-                String[] arg = new String[1];
-                arg[0] = "size must be positive number";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("size must be positive number");
             }
 
             source.put("size", s);
@@ -132,11 +121,11 @@ public class Reindex extends AbstractAction<JestResult> {
             return this;
         }
 
-        public Builder conflicts(String s) throws InvalidArgumentException {
+        public Builder conflicts(String s) throws Exception {
             if(s == null || s.equals("")) {
                 String[] arg = new String[1];
                 arg[0] = "conflicts value can't be empty";
-                throw new InvalidArgumentException(arg);
+                throw new Exception("conflicts value can't be empty");
             }
 
             source.put("conflicts", s);

--- a/jest-common/src/main/java/io/searchbox/core/Reindex.java
+++ b/jest-common/src/main/java/io/searchbox/core/Reindex.java
@@ -1,0 +1,152 @@
+package io.searchbox.core;
+
+import com.google.gson.Gson;
+import com.sun.javaws.exceptions.InvalidArgumentException;
+import io.searchbox.action.AbstractAction;
+import io.searchbox.client.JestResult;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Created by ozlevka on 5/16/16.
+ */
+public class Reindex extends AbstractAction<JestResult> {
+
+    protected Reindex(Builder builder) {
+        super(builder);
+        setURI(buildURI());
+        this.payload = builder.source;
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "POST";
+    }
+
+    @Override
+    public JestResult createNewElasticSearchResult(String responseBody, int statusCode, String reasonPhrase, Gson gson) {
+        return createNewElasticSearchResult(new JestResult(gson), responseBody, statusCode, reasonPhrase, gson);
+    }
+
+    @Override
+    protected String buildURI() {
+        return super.buildURI() + "/_reindex?wait_for_completion=true";
+    }
+
+
+    public static class Builder extends AbstractAction.Builder<Reindex, Builder> {
+        private Map<String, Object> source;
+
+        @SuppressWarnings("unchecked")
+        public Builder(String srcIndex, String destIndex) {
+            source = new HashMap<String, Object>();
+            source.put("source", new HashMap<String, Object>());
+            source.put("dest", new HashMap<String, Object>());
+
+            Map<String, Object> mp = (Map<String, Object>) source.get("source");
+            mp.put("index", srcIndex);
+
+            mp = (Map<String, Object>)source.get("dest");
+            mp.put("index", destIndex);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder(String[] srcIndexes, String destIndex) {
+            source = new HashMap<String, Object>();
+            source.put("source", new HashMap<String, Object>());
+            source.put("dest", new HashMap<String, Object>());
+
+            Map<String, Object> mp = (Map<String, Object>)source.get("source");
+            mp.put("index", srcIndexes);
+
+            mp = (Map<String, Object>)source.get("dest");
+            mp.put("index", destIndex);
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder versionType(String vt) throws InvalidArgumentException {
+            if(vt == null || vt.equals("")) {
+                String[] arg = new String[1];
+                arg[0] = "version type can't be empty";
+                throw new InvalidArgumentException(arg);
+            }
+
+            ((Map<String, Object>)source.get("dest")).put("version_type", vt);
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder operationType(String op) throws InvalidArgumentException {
+            if(op == null || op.equals("")) {
+                String[] arg = new String[1];
+                arg[0] = "operation type can't be empty";
+                throw new InvalidArgumentException(arg);
+            }
+
+            ((Map<String, Object>)source.get("dest")).put("op_type", op);
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder srcDocumentType(String doc_type) throws InvalidArgumentException {
+            if(doc_type == null || doc_type.equals("")) {
+                String[] arg = new String[1];
+                arg[0] = "document type can't be empty";
+                throw new InvalidArgumentException(arg);
+            }
+
+            ((Map<String, Object>)source.get("source")).put("type", doc_type);
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder srcDocumentType(String[] doc_types) throws InvalidArgumentException {
+            if(doc_types == null || doc_types.length == 0) {
+                String[] arg = new String[1];
+                arg[0] = "document type can't be empty";
+                throw new InvalidArgumentException(arg);
+            }
+
+            ((Map<String, Object>)source.get("source")).put("type", doc_types);
+            return this;
+        }
+
+        @SuppressWarnings("unchecked")
+        public Builder query(String query) {
+            Map<String, Object> q = (new Gson()).fromJson(query, Map.class);
+            ((Map<String, Object>)source.get("source")).put("query", q);
+
+            return this;
+        }
+
+        public Builder size(int s) throws InvalidArgumentException {
+            if(s <= 0) {
+                String[] arg = new String[1];
+                arg[0] = "size must be positive number";
+                throw new InvalidArgumentException(arg);
+            }
+
+            source.put("size", s);
+
+            return this;
+        }
+
+        public Builder conflicts(String s) throws InvalidArgumentException {
+            if(s == null || s.equals("")) {
+                String[] arg = new String[1];
+                arg[0] = "conflicts value can't be empty";
+                throw new InvalidArgumentException(arg);
+            }
+
+            source.put("conflicts", s);
+
+            return this;
+        }
+
+        @Override
+        public Reindex build() {
+            return new Reindex(this);
+        }
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/core/ReindexTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/ReindexTest.java
@@ -1,0 +1,57 @@
+package io.searchbox.core;
+
+import com.google.gson.Gson;
+import com.sun.javaws.exceptions.InvalidArgumentException;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+/**
+ * Created by ozlevka on 5/17/16.
+ */
+public class ReindexTest {
+    @Test
+    public void testReindexUri() {
+        Reindex.Builder b = new Reindex.Builder("old_index", "new_index");
+
+        Reindex ri = b.build();
+
+        String s = ri.getURI();
+        assertTrue(s.equals("/_reindex?wait_for_completion=true"));
+    }
+
+    @Test
+    public void testReindexBuilderData() {
+        Reindex.Builder b = new Reindex.Builder("old_index", "new_index");
+        try {
+            b.operationType("create")
+              .query("{\n" +
+                      "      \"term\": {\n" +
+                      "        \"user\": \"kimchy\"\n" +
+                      "      }\n" +
+                      "    }")
+              .srcDocumentType("tweet")
+              .versionType("internal")
+              .conflicts("proceed");
+        } catch (InvalidArgumentException e) {
+            e.printStackTrace();
+        }
+
+        Reindex r = b.build();
+
+        assertTrue(r.getRestMethodName().equals("POST"));
+        Gson g = new Gson();
+        String data = r.getData(g);
+
+        assertTrue(data.length() > 0);
+
+        Map<String, Object> test = g.fromJson(data, Map.class);
+
+        assertNotNull(test);
+        assertEquals(test.get("conflicts"),"proceed");
+        assertEquals(((Map<String, Object>)test.get("source")).get("index"),"old_index");
+        assertEquals(((Map<String, Object>)test.get("dest")).get("index"),"new_index");
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/core/ReindexTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/ReindexTest.java
@@ -1,7 +1,6 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
-import com.sun.javaws.exceptions.InvalidArgumentException;
 import org.junit.Test;
 
 import java.util.Map;
@@ -35,7 +34,7 @@ public class ReindexTest {
               .srcDocumentType("tweet")
               .versionType("internal")
               .conflicts("proceed");
-        } catch (InvalidArgumentException e) {
+        } catch (Exception e) {
             e.printStackTrace();
         }
 


### PR DESCRIPTION
Hi,
I create new start from 2.3.x [reindex API](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-reindex.html) implementation.

I see this API as Useful for many reasons.
Right now only sync version is implemented



 