### PR TITLE
Doc 'type' is optional in mget

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Doc.java
+++ b/jest-common/src/main/java/io/searchbox/core/Doc.java
@@ -24,12 +24,21 @@ public class Doc {
 
     private final Collection<String> fields = new LinkedList<String>();
 
+    public Doc(String index, String id) {
+        this(index, null, id);
+    }
+
+    /**
+     *
+     * @param index
+     * @param type
+     *          The mget API allows for _type to be optional.
+     *          Set it to _all or null in order to fetch the first document matching the id across all types.
+     * @param id
+     */
     public Doc(String index, String type, String id) {
         if(StringUtils.isEmpty(index)){
             throw new IllegalArgumentException("Required Index argument cannot be null or empty.");
-        }
-        if(StringUtils.isEmpty(type)){
-            throw new IllegalArgumentException("Required Type argument cannot be null or empty.");
         }
         if(StringUtils.isEmpty(id)){
             throw new IllegalArgumentException("Required Id argument cannot be null or empty.");
@@ -100,7 +109,11 @@ public class Doc {
         Map<String, Object> retval = new LinkedHashMap<String, Object>();
 
         retval.put("_index", index);
-        retval.put("_type", type);
+
+        if(StringUtils.isNotEmpty(type)) {
+            retval.put("_type", type);
+        }
+
         retval.put("_id", id);
 
         if(!fields.isEmpty()) {

--- a/jest-common/src/main/java/io/searchbox/core/MultiGet.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiGet.java
@@ -118,6 +118,11 @@ public class MultiGet extends GenericResultAbstractAction {
         public static class ByDoc extends GenericResultAbstractAction.Builder<MultiGet, ByDoc> {
             private List<Doc> docs = new LinkedList<Doc>();
 
+            /**
+             * The mget API allows for _type to be optional. Set it to _all or leave it empty in order to
+             * fetch the first document matching the id across all types. If you don’t set the type and
+             * have many documents sharing the same _id, you will end up getting only the first matching document.
+             */
             public ByDoc(Collection<? extends Doc> docs) {
                 this.docs.addAll(docs);
             }

--- a/jest-common/src/test/java/io/searchbox/core/DocTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/DocTest.java
@@ -53,10 +53,19 @@ public class DocTest {
         fail("Constructor should have thrown an exception when index was null");
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testConstructionWithNullType() {
-        new Doc("idx", null, "id");
-        fail("Constructor should have thrown an exception when type was null");
+        String index = "idx0";
+        String id = "00001_AE";
+        Map<String, Object> expectedMap = new HashMap<String, Object>();
+        expectedMap.put("_index", index);
+        expectedMap.put("_id", id);
+
+        Doc doc = new Doc(index, id);
+        Map<String, Object> actualMap = doc.toMap();
+
+        assertEquals(2, actualMap.size());
+        assertEquals(expectedMap, actualMap);
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
In elasticsearch, Doc 'type' is optional in mget request. According to elastic documentation, If you don’t set the type and have many documents sharing the same _id, you will end up getting only the first matching document.
See https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html#mget-type