### PR TITLE
Support multiple target hosts

### DIFF
--- a/jest/src/main/java/io/searchbox/client/JestClientFactory.java
+++ b/jest/src/main/java/io/searchbox/client/JestClientFactory.java
@@ -38,6 +38,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Dogukan Sonmez
@@ -97,10 +98,10 @@ public class JestClientFactory {
             log.info("Idle connection reaping disabled...");
         }
 
-        HttpHost preemptiveAuthTargetHost = httpClientConfig.getPreemptiveAuthTargetHost();
-        if (preemptiveAuthTargetHost != null) {
+        Set<HttpHost> preemptiveAuthTargetHosts = httpClientConfig.getPreemptiveAuthTargetHosts();
+        if (!preemptiveAuthTargetHosts.isEmpty()) {
             log.info("Authentication cache set for preemptive authentication");
-            client.setHttpClientContextTemplate(createPreemptiveAuthContext(preemptiveAuthTargetHost));
+            client.setHttpClientContextTemplate(createPreemptiveAuthContext(preemptiveAuthTargetHosts));
         }
 
         return client;
@@ -249,18 +250,20 @@ public class JestClientFactory {
     }
 
     // Extension point
-    protected HttpClientContext createPreemptiveAuthContext(HttpHost targetHost) {
+    protected HttpClientContext createPreemptiveAuthContext(Set<HttpHost> targetHosts) {
         HttpClientContext context = HttpClientContext.create();
         context.setCredentialsProvider(httpClientConfig.getCredentialsProvider());
-        context.setAuthCache(createBasicAuthCache(targetHost));
+        context.setAuthCache(createBasicAuthCache(targetHosts));
 
         return context;
     }
 
-    private AuthCache createBasicAuthCache(HttpHost targetHost) {
+    private AuthCache createBasicAuthCache(Set<HttpHost> targetHosts) {
         AuthCache authCache = new BasicAuthCache();
         BasicScheme basicAuth = new BasicScheme();
-        authCache.put(targetHost, basicAuth);
+        for (HttpHost eachTargetHost : targetHosts) {
+            authCache.put(eachTargetHost, basicAuth);
+        }
 
         return authCache;
     }

--- a/jest/src/main/java/io/searchbox/client/config/HttpClientConfig.java
+++ b/jest/src/main/java/io/searchbox/client/config/HttpClientConfig.java
@@ -20,8 +20,11 @@ import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 
 import java.net.ProxySelector;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * @author Dogukan Sonmez
@@ -39,7 +42,7 @@ public class HttpClientConfig extends ClientConfig {
     private final AuthenticationStrategy proxyAuthenticationStrategy;
     private final SchemeIOSessionStrategy httpIOSessionStrategy;
     private final SchemeIOSessionStrategy httpsIOSessionStrategy;
-    private HttpHost preemptiveAuthTargetHost;
+    private Set<HttpHost> preemptiveAuthTargetHosts;
 
     public HttpClientConfig(Builder builder) {
         super(builder);
@@ -53,7 +56,7 @@ public class HttpClientConfig extends ClientConfig {
         this.proxyAuthenticationStrategy = builder.proxyAuthenticationStrategy;
         this.httpIOSessionStrategy = builder.httpIOSessionStrategy;
         this.httpsIOSessionStrategy = builder.httpsIOSessionStrategy;
-        this.preemptiveAuthTargetHost = builder.preemptiveAuthTargetHost;
+        this.preemptiveAuthTargetHosts = builder.preemptiveAuthTargetHosts;
     }
 
     public Map<HttpRoute, Integer> getMaxTotalConnectionPerRoute() {
@@ -96,8 +99,8 @@ public class HttpClientConfig extends ClientConfig {
         return httpsIOSessionStrategy;
     }
 
-    public HttpHost getPreemptiveAuthTargetHost() {
-        return preemptiveAuthTargetHost;
+    public Set<HttpHost> getPreemptiveAuthTargetHosts() {
+        return preemptiveAuthTargetHosts;
     }
 
     public static class Builder extends ClientConfig.AbstractBuilder<HttpClientConfig, Builder> {
@@ -112,7 +115,7 @@ public class HttpClientConfig extends ClientConfig {
         private AuthenticationStrategy proxyAuthenticationStrategy;
         private SchemeIOSessionStrategy httpIOSessionStrategy;
         private SchemeIOSessionStrategy httpsIOSessionStrategy;
-        private HttpHost preemptiveAuthTargetHost;
+        private Set<HttpHost> preemptiveAuthTargetHosts = Collections.emptySet();
 
         public Builder(HttpClientConfig httpClientConfig) {
             super(httpClientConfig);
@@ -239,15 +242,30 @@ public class HttpClientConfig extends ClientConfig {
         }
 
         /**
-         * Sets preemptive authentication for the specified <b>target host</b> by pre-populating an authentication data cache
+         * Sets preemptive authentication for the specified <b>target host</b> by pre-populating an authentication data cache.
          * <p>
-         * It is mandatory to set a credential provider to use preemptive authentication
+         * It is mandatory to set a credentials provider to use preemptive authentication.
          * </p><p>
-         * If preemptive authentication is set without setting a credentials provider an exception will be thrown
+         * If preemptive authentication is set without setting a credentials provider an exception will be thrown.
          * </p>
          */
         public Builder setPreemptiveAuth(HttpHost targetHost) {
-            this.preemptiveAuthTargetHost = targetHost;
+            return preemptiveAuthTargetHosts(Collections.singleton(targetHost));
+        }
+
+        /**
+         * Sets preemptive authentication for the specified set of <b>target hosts</b> by pre-populating an authentication data cache.
+         * <p>
+         * It is mandatory to set a credentials provider to use preemptive authentication.
+         * </p><p>
+         * If preemptive authentication is set without setting a credentials provider an exception will be thrown.
+         * </p>
+         * @param preemptiveAuthTargetHosts set of hosts targeted for preemptive authentication
+         */
+        public Builder preemptiveAuthTargetHosts(Set<HttpHost> preemptiveAuthTargetHosts) {
+            if (preemptiveAuthTargetHosts != null) {
+                this.preemptiveAuthTargetHosts = new HashSet<HttpHost>(preemptiveAuthTargetHosts);
+            }
             return this;
         }
 
@@ -287,7 +305,7 @@ public class HttpClientConfig extends ClientConfig {
         }
 
         private boolean preemptiveAuthSetWithoutCredentials() {
-            return preemptiveAuthTargetHost != null && credentialsProvider == null;
+            return !preemptiveAuthTargetHosts.isEmpty() && credentialsProvider == null;
         }
 
     }

--- a/jest/src/test/java/io/searchbox/client/JestClientFactoryTest.java
+++ b/jest/src/test/java/io/searchbox/client/JestClientFactoryTest.java
@@ -1,5 +1,7 @@
 package io.searchbox.client;
 
+import java.util.HashSet;
+
 import io.searchbox.client.config.ClientConfig;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.client.config.discovery.NodeChecker;
@@ -20,6 +22,7 @@ import org.apache.http.nio.conn.NHttpClientConnectionManager;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import static java.util.Arrays.asList;
 import static org.junit.Assert.*;
 
 /**
@@ -120,18 +123,20 @@ public class JestClientFactoryTest {
         JestClientFactory factory = new JestClientFactory();
         CredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new UsernamePasswordCredentials("someUser", "somePassword"));
-        HttpHost targetHost = new HttpHost("targetHostName", 80, "http");
+        HttpHost targetHost1 = new HttpHost("targetHostName1", 80, "http");
+        HttpHost targetHost2 = new HttpHost("targetHostName2", 80, "http");
 
         HttpClientConfig httpClientConfig = new HttpClientConfig.Builder("someUri")
                 .credentialsProvider(credentialsProvider)
-                .setPreemptiveAuth(targetHost)
+                .preemptiveAuthTargetHosts(new HashSet<HttpHost>(asList(targetHost1, targetHost2)))
                 .build();
 
         factory.setHttpClientConfig(httpClientConfig);
         JestHttpClient jestHttpClient = (JestHttpClient) factory.getObject();
         HttpClientContext httpClientContext = jestHttpClient.getHttpClientContextTemplate();
 
-        assertNotNull(httpClientContext.getAuthCache().get(targetHost));
+        assertNotNull(httpClientContext.getAuthCache().get(targetHost1));
+        assertNotNull(httpClientContext.getAuthCache().get(targetHost2));
         assertEquals(credentialsProvider, httpClientContext.getCredentialsProvider());
     }
 

--- a/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
+++ b/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
@@ -75,7 +75,7 @@ public class HttpClientConfigTest {
 
     @Test
     public void preemptiveAuthWithMultipleTargetHosts() {
-        Set<HttpHost> targetHosts = new HashSet<HttpHost>(Arrays.asList(
+        final Set<HttpHost> targetHosts = new HashSet<HttpHost>(Arrays.asList(
                 new HttpHost("host1", 80, "http"),
                 new HttpHost("host2", 81, "https")
         ));

--- a/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
+++ b/jest/src/test/java/io/searchbox/client/config/HttpClientConfigTest.java
@@ -7,8 +7,15 @@ import org.apache.http.client.CredentialsProvider;
 import org.apache.http.impl.client.BasicCredentialsProvider;
 import org.junit.Test;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
 /**
@@ -57,13 +64,27 @@ public class HttpClientConfigTest {
         String hostName = "targetHost";
         int port = 80;
 
+        HttpHost targetHost = new HttpHost(hostName, port, "http");
         HttpClientConfig httpClientConfig = new HttpClientConfig.Builder("localhost")
                 .defaultCredentials("someUser", "somePassword")
-                .setPreemptiveAuth(new HttpHost(hostName, port, "http"))
+                .setPreemptiveAuth(targetHost)
                 .build();
 
-        assertEquals(hostName, httpClientConfig.getPreemptiveAuthTargetHost().getHostName());
-        assertEquals(port, httpClientConfig.getPreemptiveAuthTargetHost().getPort());
+        assertThat(httpClientConfig.getPreemptiveAuthTargetHosts(), hasItem(targetHost));
+    }
+
+    @Test
+    public void preemptiveAuthWithMultipleTargetHosts() {
+        Set<HttpHost> targetHosts = new HashSet<HttpHost>(Arrays.asList(
+                new HttpHost("host1", 80, "http"),
+                new HttpHost("host2", 81, "https")
+        ));
+        HttpClientConfig httpClientConfig = new HttpClientConfig.Builder("localhost")
+                .defaultCredentials("someUser", "somePassword")
+                .preemptiveAuthTargetHosts(new HashSet<HttpHost>(targetHosts))
+                .build();
+
+        assertThat(httpClientConfig.getPreemptiveAuthTargetHosts(), is(targetHosts));
     }
 
     @Test(expected = IllegalArgumentException.class)


### PR DESCRIPTION
Preemptive authentication currently only supports a single host.
This commit makes it possible to support multiple hosts, so that
you can also preemptively authenticate against multiple servers.