### PR TITLE
fix example that does not work

### DIFF
--- a/jest/README.md
+++ b/jest/README.md
@@ -139,7 +139,7 @@ An index mapping can be created via Jest with ease, just pass the mapping source
 PutMapping putMapping = new PutMapping.Builder(
         "my_index",
         "my_type",
-        "{ \"document\" : { \"properties\" : { \"message\" : {\"type\" : \"string\", \"store\" : \"yes\"} } } }"
+        "{ \"my_type\" : { \"properties\" : { \"message\" : {\"type\" : \"string\", \"store\" : \"yes\"} } } }"
 ).build();
 client.execute(putMapping);
 ```


### PR DESCRIPTION
The example yields a mapping error in elasticsearch (I have `latest`)
because `my_type` and `document` mismatch. This just sent me down
a long debugging session (I'm very new to ES)