### PR TITLE
Fix aggregation logic inconsistency

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
@@ -17,7 +17,9 @@ public class CardinalityAggregation extends MetricAggregation {
 
     public CardinalityAggregation(String name, JsonObject cardinalityAggregation) {
         super(name, cardinalityAggregation);
-        cardinality = cardinalityAggregation.get(String.valueOf(VALUE)).getAsLong();
+        if(cardinalityAggregation.has(String.valueOf(VALUE)) && !cardinalityAggregation.get(String.valueOf(VALUE)).isJsonNull()) {
+            cardinality = cardinalityAggregation.get(String.valueOf(VALUE)).getAsLong();
+        }
     }
 
     /**

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
@@ -17,9 +17,7 @@ public class CardinalityAggregation extends MetricAggregation {
 
     public CardinalityAggregation(String name, JsonObject cardinalityAggregation) {
         super(name, cardinalityAggregation);
-        if(cardinalityAggregation.has(String.valueOf(VALUE)) && !cardinalityAggregation.get(String.valueOf(VALUE)).isJsonNull()) {
-            cardinality = cardinalityAggregation.get(String.valueOf(VALUE)).getAsLong();
-        }
+        cardinality = cardinalityAggregation.get(String.valueOf(VALUE)).getAsLong();
     }
 
     /**


### PR DESCRIPTION
Fixes an issue where the CardinalityAggregation can never actually return null, despite what the comment above getCardinality() says. This change incorporates some logic that is used in the SingleValueAggregation constructor.