### PR TITLE
Allow search result hits to be extracted even if _source is disabled …

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -100,48 +100,51 @@ public class SearchResult extends JestResult {
             JsonObject hitObject = hitElement.getAsJsonObject();
             JsonObject source = hitObject.getAsJsonObject(sourceKey);
 
-            if (source != null) {
-                String index = hitObject.get("_index").getAsString();
-                String type = hitObject.get("_type").getAsString();
+            String index = hitObject.get("_index").getAsString();
+            String type = hitObject.get("_type").getAsString();
 
-                String id = hitObject.get("_id").getAsString();
+            String id = hitObject.get("_id").getAsString();
 
-                Double score = null;
-                if (hitObject.has("_score") && !hitObject.get("_score").isJsonNull()) {
-                    score = hitObject.get("_score").getAsDouble();
-                }
+            Double score = null;
+            if (hitObject.has("_score") && !hitObject.get("_score").isJsonNull()) {
+                score = hitObject.get("_score").getAsDouble();
+            }
 
-                JsonElement explanation = hitObject.get(EXPLANATION_KEY);
-                Map<String, List<String>> highlight = extractHighlight(hitObject.getAsJsonObject(HIGHLIGHT_KEY));
-                List<String> sort = extractSort(hitObject.getAsJsonArray(SORT_KEY));
+            JsonElement explanation = hitObject.get(EXPLANATION_KEY);
+            Map<String, List<String>> highlight = extractHighlight(hitObject.getAsJsonObject(HIGHLIGHT_KEY));
+            List<String> sort = extractSort(hitObject.getAsJsonArray(SORT_KEY));
 
-                JsonObject clonedSource = null;
-                for (MetaField metaField : META_FIELDS) {
-                    JsonElement metaElement = hitObject.get(metaField.esFieldName);
-                    if (metaElement != null) {
-                        if (clonedSource == null) {
+            JsonObject clonedSource = null;
+            for (MetaField metaField : META_FIELDS) {
+                JsonElement metaElement = hitObject.get(metaField.esFieldName);
+                if (metaElement != null) {
+                    if (clonedSource == null) {
+                        if (source == null) { // Support id/version extraction even if _source is disabled
+                            clonedSource = new JsonObject();
+                        }
+                        else {
                             clonedSource = (JsonObject) CloneUtils.deepClone(source);
                         }
-                        clonedSource.add(metaField.internalFieldName, metaElement);
                     }
+                    clonedSource.add(metaField.internalFieldName, metaElement);
                 }
-                if (clonedSource != null) {
-                    source = clonedSource;
-                }
-
-                hit = new Hit<T, K>(
-                        sourceType,
-                        source,
-                        explanationType,
-                        explanation,
-                        highlight,
-                        sort,
-                        index,
-                        type,
-                        id,
-                        score
-                );
             }
+            if (clonedSource != null) {
+                source = clonedSource;
+            }
+
+            hit = new Hit<T, K>(
+                    sourceType,
+                    source,
+                    explanationType,
+                    explanation,
+                    highlight,
+                    sort,
+                    index,
+                    type,
+                    id,
+                    score
+            );
         }
 
         return hit;

--- a/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
@@ -300,6 +300,44 @@ public class SearchResultTest {
         assertNotNull(hit.score);
         assertEquals("Incorrect version", someVersion, hit.source.getVersion());
     }
+    
+    @Test
+    public void testGetHitsWithoutSource() {
+    	Long version = 2L;
+    	String jsonWithoutSource = "{\n" +
+                "    \"_shards\":{\n" +
+                "        \"total\" : 5,\n" +
+                "        \"successful\" : 5,\n" +
+                "        \"failed\" : 0\n" +
+                "    },\n" +
+                "    \"hits\":{\n" +
+                "        \"total\" : 1,\n" +
+                "        \"hits\" : [\n" +
+                "            {\n" +
+                "                \"_index\" : \"twitter\",\n" +
+                "                \"_type\" : \"tweet\",\n" +
+                "                \"_score\" : \"1.02332\",\n" +
+                "                \"_id\" : \"1\",\n" +
+                "                \"_version\" : \"" + version + "\"\n" +
+                "            }\n" +
+                "        ]\n" +
+                "    }\n" +
+                "}";
+
+        SearchResult searchResult = new SearchResult(new Gson());
+        searchResult.setSucceeded(true);
+        searchResult.setJsonString(jsonWithoutSource);
+        searchResult.setJsonObject(new JsonParser().parse(jsonWithoutSource).getAsJsonObject());
+        searchResult.setPathToResult("hits/hits/_source");
+
+        SearchResult.Hit<TestObject, Void> hit = searchResult.getFirstHit(TestObject.class);
+        assertNotNull(hit.source);
+        assertNull(hit.explanation);
+        assertNull(hit.sort);
+        assertNotNull(hit.score);
+        assertEquals("1", hit.source.getId());
+        assertEquals(version, hit.source.getVersion());
+    }
 
     class TestObject {
         @JestId


### PR DESCRIPTION
…in the search request.

Previously, this would return a list of null hits, now this supports the same hit extraction including mapping the id/version onto a POJO.
