### PR TITLE
Fix hang on invalid response

### DIFF
--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -3,8 +3,10 @@ package io.searchbox.action;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
 import io.searchbox.annotations.JestId;
 import io.searchbox.client.JestResult;
 import io.searchbox.params.Parameters;
@@ -90,10 +92,16 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
     }
 
     protected JsonObject parseResponseBody(String responseBody) {
-        if (responseBody != null && !responseBody.trim().isEmpty()) {
-            return new JsonParser().parse(responseBody).getAsJsonObject();
+        if (responseBody == null || responseBody.trim().isEmpty()) {
+            return new JsonObject();
         }
-        return new JsonObject();
+
+        JsonElement parsed = new JsonParser().parse(responseBody);
+        if (parsed.isJsonObject()) {
+            return parsed.getAsJsonObject();
+        } else {
+            throw new JsonSyntaxException("Response did not contain a JSON Object");
+        }
     }
 
     public static String getIdFromSource(Object source) {

--- a/jest-common/src/main/java/io/searchbox/core/Cat.java
+++ b/jest-common/src/main/java/io/searchbox/core/Cat.java
@@ -1,8 +1,11 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
+import com.google.gson.JsonSyntaxException;
+
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
@@ -44,12 +47,18 @@ public class Cat extends AbstractAction<CatResult> {
 
     @Override
     protected JsonObject parseResponseBody(String responseBody) {
-        JsonObject result = new JsonObject();
-        if (responseBody != null && !responseBody.trim().isEmpty()) {
-            result.add(PATH_TO_RESULT, new JsonParser().parse(responseBody).getAsJsonArray());
+        if (responseBody == null || responseBody.trim().isEmpty()) {
+            return new JsonObject();
         }
 
-        return result;
+        JsonElement parsed = new JsonParser().parse(responseBody);
+        if (parsed.isJsonArray()) {
+            JsonObject result = new JsonObject();
+            result.add(PATH_TO_RESULT, parsed.getAsJsonArray());
+            return result;
+        } else {
+            throw new JsonSyntaxException("Cat response did not contain a JSON Array");
+        }
     }
 
     @Override

--- a/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
+++ b/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
@@ -181,8 +181,13 @@ public class AbstractActionTest {
     }
 
     @Test(expected = JsonSyntaxException.class)
-    public void propagateExceptionWhenTheResponseIsNotJson() {
+    public void propagateExceptionWhenTheResponseIsNotJson1() {
         new DummyAction.Builder().build().parseResponseBody("401 Unauthorized");
+    }
+
+    @Test(expected = JsonSyntaxException.class)
+    public void propagateExceptionWhenTheResponseIsNotJson2() {
+        new DummyAction.Builder().build().parseResponseBody("banana");
     }
 
 

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -231,8 +231,10 @@ public class JestHttpClient extends AbstractJestClient {
             T jestResult = null;
             try {
                 jestResult = deserializeResponse(response, request, clientRequest);
-            } catch (IOException e) {
+            } catch (Exception e) {
                 failed(e);
+            } catch (Throwable t) {
+                failed(new Exception("Problem during request processing", t));
             }
             if (jestResult != null) resultHandler.completed(jestResult);
         }

--- a/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
+++ b/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
@@ -1,6 +1,8 @@
 package io.searchbox.client.http;
 
+import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.Socket;
 import java.nio.charset.Charset;
 
 import org.littleshoot.proxy.HttpFilters;
@@ -20,14 +22,14 @@ import io.netty.handler.codec.http.HttpResponseStatus;
 import io.netty.handler.codec.http.HttpVersion;
 
 public class FailingProxy {
-    public static final int PROXY_PORT = 54321;
-
     private final HttpProxyServer server;
 
-    public FailingProxy() {
+    public FailingProxy() throws IOException {
+        int port = getUnusedPort();
+
         final HttpProxyServerBootstrap bootstrap = DefaultHttpProxyServer
                 .bootstrap()
-                .withPort(PROXY_PORT)
+                .withPort(port)
                 .withTransparent(true)
                 .withFiltersSource(new FailingSourceAdapter())
                 ;
@@ -43,6 +45,14 @@ public class FailingProxy {
 
     public void stop() {
         server.stop();
+    }
+
+    private static int getUnusedPort() throws IOException {
+        final Socket deadSocket = new Socket();
+        deadSocket.bind(null);
+        final int port = deadSocket.getLocalPort();
+        deadSocket.close();
+        return port;
     }
 
     private static class FailingSourceAdapter extends HttpFiltersSourceAdapter {


### PR DESCRIPTION
Improve error checking when server sends invalid responses. 
This could cause JestHttpClient#executeAsync to hang.

You may not agree with throwing a gson JsonSyntaxException in AbstractAction#parseResponseBody, I did it this way because there are already some tests looking for this exception. Happy to change it to some other exception.
