### PR TITLE
Update default Gson to support long values.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -5,6 +5,10 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonPrimitive;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.exception.NoServerConfiguredException;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
@@ -12,6 +16,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -26,6 +31,15 @@ public abstract class AbstractJestClient implements JestClient {
 
     protected Gson gson = new GsonBuilder()
             .setDateFormat(ELASTIC_SEARCH_DATE_FORMAT)
+            .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
+                @Override
+                public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
+                    if (src == src.longValue()) {
+                        return new JsonPrimitive(src.longValue());
+                    }
+                    return new JsonPrimitive(src);
+                }
+            })
             .create();
 
     private final static Logger log = LoggerFactory.getLogger(AbstractJestClient.class);


### PR DESCRIPTION
Background:
When a Search object is prepared for an HttpRequest the payload of a
query remains untouched except when sorting. When sorting the Search
object deserializes the query to a Map using Gson. The Gson by default
serializes Numbers to Doubles. If you happened to use a Long of '1234'
it will be converted to '1234.0'. Upon serialization a query's search
value will not reflect the original setting.

Code Changes:
- Modified the default Gson to support long values by adding a custom
  serializer to the default Gson.
- Added a Unit Test to verify longs remain longs.

Resolves: #335
