### PR TITLE
Fix #421 - Avoid decimal and scientific notation for longs

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -72,6 +72,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>

--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -5,10 +5,6 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonPrimitive;
-import com.google.gson.JsonSerializationContext;
-import com.google.gson.JsonSerializer;
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.exception.NoServerConfiguredException;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
@@ -16,7 +12,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -31,15 +26,6 @@ public abstract class AbstractJestClient implements JestClient {
 
     protected Gson gson = new GsonBuilder()
             .setDateFormat(ELASTIC_SEARCH_DATE_FORMAT)
-            .registerTypeAdapter(Double.class, new JsonSerializer<Double>() {
-                @Override
-                public JsonElement serialize(Double src, Type typeOfSrc, JsonSerializationContext context) {
-                    if (src == src.longValue()) {
-                        return new JsonPrimitive(src.longValue());
-                    }
-                    return new JsonPrimitive(src);
-                }
-            })
             .create();
 
     private final static Logger log = LoggerFactory.getLogger(AbstractJestClient.class);

--- a/jest-common/src/main/java/io/searchbox/core/search/sort/Sort.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/sort/Sort.java
@@ -1,7 +1,7 @@
 package io.searchbox.core.search.sort;
 
-import java.util.HashMap;
-import java.util.Map;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 
 /**
  * @author Riccardo Tasso
@@ -39,22 +39,22 @@ public class Sort {
         this.unmapped = true;
     }
 
-    public Map<String, Object> toMap() {
-        Map<String, Object> innerMap = new HashMap<String, Object>();
-
+    public JsonObject toJsonObject() {
+        JsonObject sortDefinition = new JsonObject();
         if (order != null) {
-            innerMap.put("order", order.toString());
+            sortDefinition.add("order", new JsonPrimitive(order.toString()));
         }
         if (missing != null) {
-            innerMap.put("missing", missing.toString());
+            sortDefinition.add("missing", new JsonPrimitive(missing.toString()));
         }
         if (unmapped != null) {
-            innerMap.put("ignore_unmapped", unmapped);
+            sortDefinition.add("ignore_unmapped", new JsonPrimitive(unmapped));
         }
 
-        Map<String, Object> rootMap = new HashMap<String, Object>();
-        rootMap.put(field, innerMap);
-        return rootMap;
+        JsonObject sortObject = new JsonObject();
+        sortObject.add(field, sortDefinition);
+
+        return sortObject;
     }
 
     public enum Sorting {

--- a/jest-common/src/test/java/io/searchbox/client/AbstractJestClientTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/AbstractJestClientTest.java
@@ -14,8 +14,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import static junit.framework.Assert.assertEquals;
-import static junit.framework.Assert.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 /**
  * @author Dogukan Sonmez

--- a/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/JestResultTest.java
@@ -1,19 +1,23 @@
 package io.searchbox.client;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
 import io.searchbox.annotations.JestId;
-
-import org.junit.Test;
-
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
 
 /**
  * @author Dogukan Sonmez
@@ -127,9 +131,9 @@ public class JestResultTest {
         assertEquals("trying out Elastic Search", twitter.getMessage());
         assertEquals("2009-11-15T14:12:12", twitter.getPostDate());
     }
-    
+
     @Test
-    public void getGetSourceAsString() {
+    public void getGetSourceAsString() throws JSONException {
         String response = "{\n" +
                 "    \"_index\" : \"twitter\",\n" +
                 "    \"_type\" : \"tweet\",\n" +
@@ -140,21 +144,21 @@ public class JestResultTest {
                 "        \"message\" : \"trying out Elastic Search\"\n" +
                 "    }\n" +
                 "}\n";
-        
+
         result.setJsonMap(new Gson().fromJson(response, Map.class));
         result.setPathToResult("_source");
         result.setSucceeded(true);
-        
+
         String onlySource = "{" +
                 "\"user\":\"kimchy\"," +
                 "\"postDate\":\"2009-11-15T14:12:12\"," +
                 "\"message\":\"trying out Elastic Search\"" +
                 "}";
-        assertEquals(onlySource, result.getSourceAsString());
+        JSONAssert.assertEquals(onlySource, result.getSourceAsString(), false);
     }
-    
+
     @Test
-    public void getGetSourceAsStringArray() {
+    public void getGetSourceAsStringArray() throws JSONException {
         String response = "{\n" +
                 "    \"_index\" : \"twitter\",\n" +
                 "    \"_type\" : \"tweet\",\n" +
@@ -165,19 +169,19 @@ public class JestResultTest {
                 "        { \"user\" : \"ionex\" }" +
                 "    ]\n" +
                 "}\n";
-        
+
         result.setJsonMap(new Gson().fromJson(response, Map.class));
         result.setPathToResult("_source");
         result.setSucceeded(true);
-        
+
         String onlySource = "[" +
                 "{\"user\":\"kimch\"}," +
                 "{\"user\":\"bello\"}," +
                 "{\"user\":\"ionex\"}" +
                 "]";
-        assertEquals(onlySource, result.getSourceAsString());
+        JSONAssert.assertEquals(onlySource, result.getSourceAsString(), false);
     }
-    
+
     @Test
     public void getGetSourceAsStringNoResult() {
         String response = "{\n" +
@@ -185,7 +189,7 @@ public class JestResultTest {
                 "    \"_type\" : \"tweet\",\n" +
                 "    \"_id\" : \"1\" \n" +
                 "}\n";
-        
+
         result.setJsonMap(new Gson().fromJson(response, Map.class));
         result.setPathToResult("_source");
         result.setSucceeded(true);

--- a/jest-common/src/test/java/io/searchbox/core/BulkTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/BulkTest.java
@@ -1,12 +1,15 @@
 package io.searchbox.core;
 
-import com.google.gson.Gson;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static junit.framework.Assert.assertEquals;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.gson.Gson;
 
 /**
  * @author Dogukan Sonmez
@@ -19,7 +22,7 @@ public class BulkTest {
     }
 
     @Test
-    public void bulkOperationWithIndex() {
+    public void bulkOperationWithIndex() throws JSONException {
         Map source = new HashMap();
         source.put("field", "value");
 
@@ -29,22 +32,22 @@ public class BulkTest {
         executeAsserts(bulk);
         String expectedData = "{\"index\":{\"_id\":\"1\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}\n" +
                 "{\"field\":\"value\"}";
-        assertEquals(expectedData.trim(), bulk.getData(new Gson()).toString().trim());
+        JSONAssert.assertEquals(expectedData, bulk.getData(new Gson()).toString(), false);
     }
 
     @Test
-    public void bulkOperationWithSingleDelete() {
+    public void bulkOperationWithSingleDelete() throws JSONException {
         Bulk bulk = new Bulk.Builder()
                 .addAction(new Delete.Builder("1").index("twitter").type("tweet").build())
                 .build();
 
         executeAsserts(bulk);
         String expectedData = "{\"delete\":{\"_id\":\"1\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}\n";
-        assertEquals(expectedData.trim(), bulk.getData(new Gson()).toString().trim());
+        JSONAssert.assertEquals(expectedData, bulk.getData(new Gson()).toString(), false);
     }
 
     @Test
-    public void bulkOperationWithMultipleIndex() {
+    public void bulkOperationWithMultipleIndex() throws JSONException {
         Map source = new HashMap();
         source.put("field", "value");
 
@@ -58,11 +61,11 @@ public class BulkTest {
                 "{\"field\":\"value\"}\n" +
                 "{\"index\":{\"_id\":\"2\",\"_index\":\"elasticsearch\",\"_type\":\"jest\"}}\n" +
                 "{\"field\":\"value\"}";
-        assertEquals(expectedData.trim(), bulk.getData(new Gson()).toString().trim());
+        JSONAssert.assertEquals(expectedData, bulk.getData(new Gson()).toString(), false);
     }
 
     @Test
-    public void bulkOperationWithMultipleDelete() {
+    public void bulkOperationWithMultipleDelete() throws JSONException {
         Bulk bulk = new Bulk.Builder()
                 .addAction(new Delete.Builder("1").index("twitter").type("tweet").build())
                 .addAction(new Delete.Builder("2").index("twitter").type("tweet").build())
@@ -71,11 +74,11 @@ public class BulkTest {
         executeAsserts(bulk);
         String expectedData = "{\"delete\":{\"_id\":\"1\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}\n" +
                 "{\"delete\":{\"_id\":\"2\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}";
-        assertEquals(expectedData.trim(), bulk.getData(new Gson()).toString().trim());
+        JSONAssert.assertEquals(expectedData, bulk.getData(new Gson()).toString(), false);
     }
 
     @Test
-    public void bulkOperationWithMultipleIndexAndDelete() {
+    public void bulkOperationWithMultipleIndexAndDelete() throws JSONException {
         Map source = new HashMap();
         source.put("field", "value");
 
@@ -93,7 +96,7 @@ public class BulkTest {
                 "{\"field\":\"value\"}\n" +
                 "{\"delete\":{\"_id\":\"1\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}\n" +
                 "{\"delete\":{\"_id\":\"2\",\"_index\":\"twitter\",\"_type\":\"tweet\"}}";
-        assertEquals(expectedData.trim(), bulk.getData(new Gson()).trim());
+        JSONAssert.assertEquals(expectedData, bulk.getData(new Gson()), false);
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/core/DeleteByQueryTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/DeleteByQueryTest.java
@@ -2,7 +2,7 @@ package io.searchbox.core;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/core/ExplainTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/ExplainTest.java
@@ -2,7 +2,7 @@ package io.searchbox.core;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/core/MultiGetTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/MultiGetTest.java
@@ -1,12 +1,15 @@
 package io.searchbox.core;
 
-import com.google.gson.Gson;
-import org.junit.Test;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotEquals;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.gson.Gson;
 
 /**
  * @author Dogukan Sonmez
@@ -18,16 +21,16 @@ public class MultiGetTest {
     Doc doc3 = new Doc("twitter", "tweet", "3");
 
     @Test
-    public void getMultipleDocs() {
+    public void getMultipleDocs() throws JSONException {
         MultiGet get = new MultiGet.Builder.ByDoc(Arrays.asList(doc1, doc2, doc3)).build();
 
         assertEquals("GET", get.getRestMethodName());
         assertEquals("/_mget", get.getURI());
-        assertEquals("{\"docs\":[" +
+        JSONAssert.assertEquals("{\"docs\":[" +
                 "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"1\"}," +
                 "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"2\"}," +
                 "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"3\"}]}",
-                get.getData(new Gson()));
+                get.getData(new Gson()), false);
     }
 
     @Test
@@ -47,12 +50,12 @@ public class MultiGetTest {
     }
 
     @Test
-    public void getDocumentWithMultipleIds() {
+    public void getDocumentWithMultipleIds() throws JSONException {
         MultiGet get = new MultiGet.Builder.ById("twitter", "tweet").addId(Arrays.asList("1", "2", "3")).build();
 
         assertEquals("GET", get.getRestMethodName());
         assertEquals("twitter/tweet/_mget", get.getURI());
-        assertEquals("{\"ids\":[\"1\",\"2\",\"3\"]}", get.getData(new Gson()));
+        JSONAssert.assertEquals("{\"ids\":[\"1\",\"2\",\"3\"]}", get.getData(new Gson()), false);
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/core/MultiSearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/MultiSearchTest.java
@@ -1,10 +1,12 @@
 package io.searchbox.core;
 
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**
@@ -13,7 +15,7 @@ import static org.junit.Assert.assertNotEquals;
 public class MultiSearchTest {
 
     @Test
-    public void singleMultiSearchWithoutIndex() {
+    public void singleMultiSearchWithoutIndex() throws JSONException {
         String expectedData = " {\"index\" : \"_all\"}\n" +
                 "{\"query\" : {\"match_all\" : {}}}\n";
         Search search = new Search.Builder("{\"query\" : {\"match_all\" : {}}}").build();
@@ -22,11 +24,11 @@ public class MultiSearchTest {
 
         assertEquals("POST", multiSearch.getRestMethodName());
         assertEquals("/_msearch", multiSearch.getURI());
-        assertEquals(expectedData.trim(), multiSearch.getData(null).toString().trim());
+        JSONAssert.assertEquals(expectedData, multiSearch.getData(null).toString(), false);
     }
 
     @Test
-    public void singleMultiSearchWitIndex() {
+    public void singleMultiSearchWitIndex() throws JSONException {
         String expectedData = " {\"index\" : \"twitter\"}\n" +
                 "{\"query\" : {\"match_all\" : {}}}\n";
         Search search = new Search.Builder("{\"query\" : {\"match_all\" : {}}}")
@@ -37,11 +39,11 @@ public class MultiSearchTest {
 
         assertEquals("POST", multiSearch.getRestMethodName());
         assertEquals("/_msearch", multiSearch.getURI());
-        assertEquals(expectedData.trim(), multiSearch.getData(null).toString().trim());
+        JSONAssert.assertEquals(expectedData, multiSearch.getData(null).toString(), false);
     }
 
     @Test
-    public void multiSearchWitIndex() {
+    public void multiSearchWitIndex() throws JSONException {
         String expectedData = " {\"index\" : \"twitter\"}\n" +
                 "{\"query\" : {\"match_all\" : {}}}\n" +
                 "{\"index\" : \"_all\"}\n" +
@@ -55,7 +57,7 @@ public class MultiSearchTest {
 
         assertEquals("POST", multiSearch.getRestMethodName());
         assertEquals("/_msearch", multiSearch.getURI());
-        assertEquals(expectedData.trim(), multiSearch.getData(null).toString().trim());
+        JSONAssert.assertEquals(expectedData, multiSearch.getData(null).toString(), false);
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/core/PercolateTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/PercolateTest.java
@@ -2,7 +2,7 @@ package io.searchbox.core;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/core/SearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchTest.java
@@ -9,7 +9,9 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -232,7 +234,7 @@ public class SearchTest {
     }
 
     @Test
-    public void addSortShouldNotOverrideExistingSortDefinitions() {
+    public void addSortShouldNotOverrideExistingSortDefinitions() throws JSONException {
         JsonArray sortClause = buildSortClause(
                 "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": [{\"existing\": { \"order\": \"desc\" }}]}",
                 Arrays.asList(sortByPopulationAsc, sortByPopulationDesc)
@@ -241,13 +243,13 @@ public class SearchTest {
         assertNotNull(sortClause);
         assertEquals(3, sortClause.size());
 
-        assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString());
-        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
-        assertEquals("{\"population\":{\"order\":\"desc\"}}", sortClause.get(2).toString());
+        JSONAssert.assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString(), false);
+        JSONAssert.assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString(), false);
+        JSONAssert.assertEquals("{\"population\":{\"order\":\"desc\"}}", sortClause.get(2).toString(), false);
     }
 
     @Test
-    public void supportElasticsearchPermissiveSortSyntax() {
+    public void supportElasticsearchPermissiveSortSyntax() throws JSONException {
         JsonArray sortClause = buildSortClause(
                 "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": \"existing\"}",
                 Arrays.asList(sortByPopulationAsc)
@@ -278,8 +280,8 @@ public class SearchTest {
         assertNotNull(sortClause);
         assertEquals(2, sortClause.size());
 
-        assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString());
-        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
+        JSONAssert.assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString(), false);
+        JSONAssert.assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString(), false);
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/core/SearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
+import java.util.List;
 
 import org.junit.Test;
 
@@ -147,6 +148,52 @@ public class SearchTest {
     }
 
     @Test
+    public void supportElasticsearchPermissiveSourceFilteringSyntax() {
+        String query = "{\"query\" : { \"term\" : { \"name\" : \"KangSungJeon\" } }, \"_source\": false}";
+        String includePatternItem1 = "SeolaIncludeFieldName";
+        String excludePatternItem1 = "SeolaExcludeField.*";
+
+        Action search = new Search.Builder(query)
+                .addSourceIncludePattern(includePatternItem1)
+                .addSourceExcludePattern(excludePatternItem1)
+                .build();
+
+        JsonParser parser = new JsonParser();
+        JsonElement parsed = parser.parse(search.getData(new Gson()).toString());
+        JsonObject obj = parsed.getAsJsonObject();
+        JsonObject source = obj.getAsJsonObject("_source");
+
+        JsonArray includePattern = source.getAsJsonArray("include");
+        assertEquals(1, includePattern.size());
+        assertEquals(includePatternItem1, includePattern.get(0).getAsString());
+
+        JsonArray excludePattern = source.getAsJsonArray("exclude");
+        assertEquals(1, excludePattern.size());
+        assertEquals(excludePatternItem1, excludePattern.get(0).getAsString());
+
+        query = "{\"query\" : { \"term\" : { \"name\" : \"KangSungJeon\" } }, \"_source\": [\"includeFieldName1\", \"includeFieldName2\"]}";
+
+        search = new Search.Builder(query)
+                .addSourceIncludePattern(includePatternItem1)
+                .addSourceExcludePattern(excludePatternItem1)
+                .build();
+
+        parsed = parser.parse(search.getData(new Gson()).toString());
+        obj = parsed.getAsJsonObject();
+        source = obj.getAsJsonObject("_source");
+
+        includePattern = source.getAsJsonArray("include");
+        assertEquals(3, includePattern.size());
+        assertEquals("includeFieldName1", includePattern.get(0).getAsString());
+        assertEquals("includeFieldName2", includePattern.get(1).getAsString());
+        assertEquals(includePatternItem1, includePattern.get(2).getAsString());
+
+        excludePattern = source.getAsJsonArray("exclude");
+        assertEquals(1, excludePattern.size());
+        assertEquals(excludePatternItem1, excludePattern.get(0).getAsString());
+    }
+
+    @Test
     public void sortTest() {
         String query = "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }}";
         Action search = new Search.Builder(query)
@@ -186,21 +233,53 @@ public class SearchTest {
 
     @Test
     public void addSortShouldNotOverrideExistingSortDefinitions() {
-        String query = "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": [{\"existing\": { \"order\": \"desc\" }}]}";
-        Action search = new Search.Builder(query)
-                .addSort(Arrays.asList(sortByPopulationAsc, sortByPopulationDesc)).build();
+        JsonArray sortClause = buildSortClause(
+                "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": [{\"existing\": { \"order\": \"desc\" }}]}",
+                Arrays.asList(sortByPopulationAsc, sortByPopulationDesc)
+        );
 
-        JsonParser parser = new JsonParser();
-        JsonElement parsed = parser.parse(search.getData(new Gson()));
-        JsonObject obj = parsed.getAsJsonObject();
-        JsonArray sort = obj.getAsJsonArray("sort");
+        assertNotNull(sortClause);
+        assertEquals(3, sortClause.size());
 
-        assertNotNull(sort);
-        assertEquals(3, sort.size());
+        assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString());
+        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
+        assertEquals("{\"population\":{\"order\":\"desc\"}}", sortClause.get(2).toString());
+    }
 
-        assertEquals("{\"existing\":{\"order\":\"desc\"}}", sort.get(0).toString());
-        assertEquals("{\"population\":{\"order\":\"asc\"}}", sort.get(1).toString());
-        assertEquals("{\"population\":{\"order\":\"desc\"}}", sort.get(2).toString());
+    @Test
+    public void supportElasticsearchPermissiveSortSyntax() {
+        JsonArray sortClause = buildSortClause(
+                "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": \"existing\"}",
+                Arrays.asList(sortByPopulationAsc)
+        );
+
+        assertNotNull(sortClause);
+        assertEquals(2, sortClause.size());
+
+        assertEquals("{\"existing\":{\"order\":\"asc\"}}", sortClause.get(0).toString());
+        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
+
+        sortClause = buildSortClause(
+                "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": \"_score\"}",
+                Arrays.asList(sortByPopulationAsc)
+        );
+
+        assertNotNull(sortClause);
+        assertEquals(2, sortClause.size());
+
+        assertEquals("{\"_score\":{\"order\":\"desc\"}}", sortClause.get(0).toString());
+        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
+
+        sortClause = buildSortClause(
+                "{\"query\" : { \"term\" : { \"name\" : \"Milano\" } }, \"sort\": { \"existing\": {\"order\":\"desc\"} }}",
+                Arrays.asList(sortByPopulationAsc)
+        );
+
+        assertNotNull(sortClause);
+        assertEquals(2, sortClause.size());
+
+        assertEquals("{\"existing\":{\"order\":\"desc\"}}", sortClause.get(0).toString());
+        assertEquals("{\"population\":{\"order\":\"asc\"}}", sortClause.get(1).toString());
     }
 
     @Test
@@ -237,5 +316,16 @@ public class SearchTest {
                 .addSort(sortByPopulationDesc).build();
 
         assertNotEquals(search1, search1Duplicate);
+    }
+
+    private JsonArray buildSortClause(String query, List<Sort> sorts) {
+        Action search = new Search.Builder(query).addSort(sorts).build();
+
+        JsonParser parser = new JsonParser();
+        Gson gson = new Gson();
+        JsonElement parsed = parser.parse(search.getData(gson));
+        JsonObject obj = parsed.getAsJsonObject();
+
+        return obj.getAsJsonArray("sort");
     }
 }

--- a/jest-common/src/test/java/io/searchbox/core/ValidateTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/ValidateTest.java
@@ -2,7 +2,7 @@ package io.searchbox.core;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationTermTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationTermTest.java
@@ -1,26 +1,24 @@
 package io.searchbox.core.search.aggregation;
 
-import static org.junit.Assert.*;
-import io.searchbox.core.BulkResult;
-import io.searchbox.core.search.aggregation.TermsAggregation.Entry;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import java.util.List;
-import java.util.Map;
 
-import org.junit.Before;
 import org.junit.Test;
 
 import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
+import io.searchbox.core.search.aggregation.TermsAggregation.Entry;
 
 public class TermsAggregationTermTest {
 
 	private static String EXPECTED_KEY_VALUE = "someKeyValue";
 	private static String EXPECTED_KEY_AS_STRING_VALUE = "someKeyAsStringValue";
-	private static long EXPECTED_DOC_COUNT_VALUE = 100L; 
-	
+	private static long EXPECTED_DOC_COUNT_VALUE = 100L;
+
 	static String termObjectWithKeyAsStringField = "{\n" +
 			"    \"key\": \"" + EXPECTED_KEY_VALUE + "\",\n" +
 			"    \"key_as_string\": \"" + EXPECTED_KEY_AS_STRING_VALUE + "\",\n" +
@@ -31,22 +29,22 @@ public class TermsAggregationTermTest {
 			"    \"key\": \"" + EXPECTED_KEY_VALUE + "\",\n" +
 			"    \"doc_count\": " + EXPECTED_DOC_COUNT_VALUE + "\n" +
 			"}";
-	
+
 	static String termsAggregationContent = "{\n" +
 			"    \"doc_count_error_upper_bound\":0,\n" +
 			"    \"sum_other_doc_count\":0,\n" +
 			"    \"buckets\": [\n" +
-				termObjectWithKeyAsStringField + 
+				termObjectWithKeyAsStringField +
 			"    ,\n" +
 				termObjectWithoutKeyAsStringField +
 			"    ]\n" +
 			"}";
-	
+
 
 
 	@Test
 	public void testParseBuckets() {
-		
+
 		JsonObject termsAggregationJson = new Gson().fromJson(termsAggregationContent, JsonObject.class);
 		TermsAggregation termsAggregation = new TermsAggregation("termsAggregation", termsAggregationJson);
 		List<Entry> buckets = termsAggregation.getBuckets();
@@ -63,7 +61,7 @@ public class TermsAggregationTermTest {
 		// If key_as_string wasn't populated, return key value
 		assertEquals(EXPECTED_KEY_VALUE, entryWithoutKeyAsString.getKeyAsString());
 		assertTrue(EXPECTED_DOC_COUNT_VALUE == entryWithoutKeyAsString.getCount());
-		
+
 	}
 
 }

--- a/jest-common/src/test/java/io/searchbox/core/search/sort/SortTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/search/sort/SortTest.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.sort;
 
-import static org.junit.Assert.assertEquals;
-
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
@@ -17,90 +17,90 @@ import io.searchbox.core.search.sort.Sort.Sorting;
 public class SortTest {
 
     @Test
-    public void testJsonSerializationForSimpleFieldSort() {
+    public void testJsonSerializationForSimpleFieldSort() throws JSONException {
         String expectedJson = "{\"my_field\":{}}";
         Sort s = new Sort("my_field");
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForAscOrder() {
+    public void testJsonSerializationForAscOrder() throws JSONException {
         String expectedJson = "{\"my_field\":{\"order\":\"asc\"}}";
         Sort s = new Sort("my_field", Sort.Sorting.ASC);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForDescOrder() {
+    public void testJsonSerializationForDescOrder() throws JSONException {
         String expectedJson = "{\"my_field\":{\"order\":\"desc\"}}";
         Sort s = new Sort("my_field", Sorting.DESC);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForMissingValueFirst() {
+    public void testJsonSerializationForMissingValueFirst() throws JSONException {
         String expectedJson = "{\"my_field\":{\"missing\":\"_first\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(Missing.FIRST);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForMissingValueLast() {
+    public void testJsonSerializationForMissingValueLast() throws JSONException {
         String expectedJson = "{\"my_field\":{\"missing\":\"_last\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(Missing.LAST);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForMissingValueString() {
+    public void testJsonSerializationForMissingValueString() throws JSONException {
         String expectedJson = "{\"my_field\":{\"missing\":\"***\"}}";
         Sort s = new Sort("my_field");
         s.setMissing("***");
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationForMissingValueInteger() {
+    public void testJsonSerializationForMissingValueInteger() throws JSONException {
         String expectedJson = "{\"my_field\":{\"missing\":\"-1\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(-1);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationWithOrderAndMissingValue() {
+    public void testJsonSerializationWithOrderAndMissingValue() throws JSONException {
         String expectedJson = "{\"my_field\":{\"order\":\"desc\",\"missing\":\"-1\"}}";
         Sort s = new Sort("my_field", Sorting.DESC);
         s.setMissing(-1);
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
     @Test
-    public void testJsonSerializationWithUnmappedValue() {
+    public void testJsonSerializationWithUnmappedValue() throws JSONException {
         String expectedJson = "{\"my_field\":{\"ignore_unmapped\":true}}";
         Sort s = new Sort("my_field");
         s.setIgnoreUnmapped();
         JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
+        JSONAssert.assertEquals(expectedJson, new Gson().toJson(actualJsonObject), false);
     }
 
 }

--- a/jest-common/src/test/java/io/searchbox/core/search/sort/SortTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/search/sort/SortTest.java
@@ -1,13 +1,14 @@
 package io.searchbox.core.search.sort;
 
-import com.google.gson.Gson;
-import io.searchbox.core.search.sort.Sort.Missing;
-import io.searchbox.core.search.sort.Sort.Sorting;
+import static org.junit.Assert.assertEquals;
+
 import org.junit.Test;
 
-import java.util.Map;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
-import static junit.framework.Assert.assertEquals;
+import io.searchbox.core.search.sort.Sort.Missing;
+import io.searchbox.core.search.sort.Sort.Sorting;
 
 /**
  * @author Riccardo Tasso
@@ -19,27 +20,27 @@ public class SortTest {
     public void testJsonSerializationForSimpleFieldSort() {
         String expectedJson = "{\"my_field\":{}}";
         Sort s = new Sort("my_field");
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
     public void testJsonSerializationForAscOrder() {
         String expectedJson = "{\"my_field\":{\"order\":\"asc\"}}";
         Sort s = new Sort("my_field", Sort.Sorting.ASC);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
     public void testJsonSerializationForDescOrder() {
         String expectedJson = "{\"my_field\":{\"order\":\"desc\"}}";
         Sort s = new Sort("my_field", Sorting.DESC);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
@@ -47,9 +48,9 @@ public class SortTest {
         String expectedJson = "{\"my_field\":{\"missing\":\"_first\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(Missing.FIRST);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
@@ -57,9 +58,9 @@ public class SortTest {
         String expectedJson = "{\"my_field\":{\"missing\":\"_last\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(Missing.LAST);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
@@ -67,9 +68,9 @@ public class SortTest {
         String expectedJson = "{\"my_field\":{\"missing\":\"***\"}}";
         Sort s = new Sort("my_field");
         s.setMissing("***");
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
@@ -77,19 +78,19 @@ public class SortTest {
         String expectedJson = "{\"my_field\":{\"missing\":\"-1\"}}";
         Sort s = new Sort("my_field");
         s.setMissing(-1);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
     public void testJsonSerializationWithOrderAndMissingValue() {
-        String expectedJson = "{\"my_field\":{\"missing\":\"-1\",\"order\":\"desc\"}}";
+        String expectedJson = "{\"my_field\":{\"order\":\"desc\",\"missing\":\"-1\"}}";
         Sort s = new Sort("my_field", Sorting.DESC);
         s.setMissing(-1);
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
     @Test
@@ -97,9 +98,9 @@ public class SortTest {
         String expectedJson = "{\"my_field\":{\"ignore_unmapped\":true}}";
         Sort s = new Sort("my_field");
         s.setIgnoreUnmapped();
-        Map actualMap = s.toMap();
+        JsonObject actualJsonObject = s.toJsonObject();
 
-        assertEquals(expectedJson, new Gson().toJson(actualMap));
+        assertEquals(expectedJson, new Gson().toJson(actualJsonObject));
     }
 
 }

--- a/jest-common/src/test/java/io/searchbox/indices/CreateIndexTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/CreateIndexTest.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/indices/IndicesExistsTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/IndicesExistsTest.java
@@ -2,7 +2,7 @@ package io.searchbox.indices;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/indices/aliases/AddAliasMappingTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/aliases/AddAliasMappingTest.java
@@ -1,12 +1,13 @@
 package io.searchbox.indices.aliases;
 
-import com.google.gson.Gson;
-import org.elasticsearch.common.collect.MapBuilder;
-import org.junit.Test;
-
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.gson.Gson;
 
 /**
  * @author cihat keser
@@ -20,18 +21,18 @@ public class AddAliasMappingTest {
             .immutableMap();
 
     @Test
-    public void testBasicGetDataForJson() {
+    public void testBasicGetDataForJson() throws JSONException {
         AddAliasMapping addAliasMapping = new AddAliasMapping
                 .Builder("tIndex", "tAlias")
                 .build();
         String actualJson = new Gson().toJson(addAliasMapping.getData());
         String expectedJson = "[{\"add\":{\"index\":\"tIndex\",\"alias\":\"tAlias\"}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
     @Test
-    public void testGetDataForJsonWithFilter() {
+    public void testGetDataForJsonWithFilter() throws JSONException {
         AddAliasMapping addAliasMapping = new AddAliasMapping
                 .Builder("tIndex", "tAlias")
                 .setFilter(USER_FILTER_JSON)
@@ -39,11 +40,11 @@ public class AddAliasMappingTest {
         String actualJson = new Gson().toJson(addAliasMapping.getData());
         String expectedJson = "[{\"add\":{\"index\":\"tIndex\",\"alias\":\"tAlias\",\"filter\":{\"term\":{\"user\":\"kimchy\"}}}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
     @Test
-    public void testGetDataForJsonWithFilterAndRouting() {
+    public void testGetDataForJsonWithFilterAndRouting() throws JSONException {
         AddAliasMapping addAliasMapping = new AddAliasMapping
                 .Builder("tIndex", "tAlias")
                 .setFilter(USER_FILTER_JSON)
@@ -53,7 +54,7 @@ public class AddAliasMappingTest {
         String expectedJson = "[{\"add\":{\"index\":\"tIndex\",\"alias\":\"tAlias\"," +
                 "\"filter\":{\"term\":{\"user\":\"kimchy\"}},\"search_routing\":\"1\",\"index_routing\":\"1\"}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
 }

--- a/jest-common/src/test/java/io/searchbox/indices/aliases/RemoveAliasMappingTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/aliases/RemoveAliasMappingTest.java
@@ -1,12 +1,13 @@
 package io.searchbox.indices.aliases;
 
-import com.google.gson.Gson;
-import org.elasticsearch.common.collect.MapBuilder;
-import org.junit.Test;
-
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
+import org.elasticsearch.common.collect.MapBuilder;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import com.google.gson.Gson;
 
 /**
  * @author cihat keser
@@ -20,18 +21,18 @@ public class RemoveAliasMappingTest {
             .immutableMap();
 
     @Test
-    public void testBasicGetDataForJson() {
+    public void testBasicGetDataForJson() throws JSONException {
         RemoveAliasMapping addAliasMapping = new RemoveAliasMapping
                 .Builder("tIndex", "tAlias")
                 .build();
         String actualJson = new Gson().toJson(addAliasMapping.getData()).toString();
         String expectedJson = "[{\"remove\":{\"index\":\"tIndex\",\"alias\":\"tAlias\"}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
     @Test
-    public void testGetDataForJsonWithFilter() {
+    public void testGetDataForJsonWithFilter() throws JSONException {
         RemoveAliasMapping addAliasMapping = new RemoveAliasMapping
                 .Builder("tIndex", "tAlias")
                 .setFilter(USER_FILTER_JSON)
@@ -39,11 +40,11 @@ public class RemoveAliasMappingTest {
         String actualJson = new Gson().toJson(addAliasMapping.getData()).toString();
         String expectedJson = "[{\"remove\":{\"index\":\"tIndex\",\"alias\":\"tAlias\",\"filter\":{\"term\":{\"user\":\"kimchy\"}}}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
     @Test
-    public void testGetDataForJsonWithFilterAndRouting() {
+    public void testGetDataForJsonWithFilterAndRouting() throws JSONException {
         RemoveAliasMapping addAliasMapping = new RemoveAliasMapping
                 .Builder("tIndex", "tAlias")
                 .setFilter(USER_FILTER_JSON)
@@ -52,7 +53,7 @@ public class RemoveAliasMappingTest {
         String actualJson = new Gson().toJson(addAliasMapping.getData()).toString();
         String expectedJson = "[{\"remove\":{\"index\":\"tIndex\",\"alias\":\"tAlias\",\"filter\":{\"term\":{\"user\":\"kimchy\"}},\"search_routing\":\"1\",\"index_routing\":\"1\"}}]";
 
-        assertEquals(expectedJson, actualJson);
+        JSONAssert.assertEquals(expectedJson, actualJson, false);
     }
 
 }

--- a/jest-common/src/test/java/io/searchbox/indices/type/TypeExistTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/type/TypeExistTest.java
@@ -2,7 +2,7 @@ package io.searchbox.indices.type;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
 /**

--- a/jest-common/src/test/java/io/searchbox/snapshot/CreateSnapshotRepositoryTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/CreateSnapshotRepositoryTest.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/CreateSnapshotTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/CreateSnapshotTest.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/DeleteSnapshotRepositoryTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/DeleteSnapshotRepositoryTest.java
@@ -2,7 +2,7 @@ package io.searchbox.snapshot;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/DeleteSnapshotTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/DeleteSnapshotTest.java
@@ -2,7 +2,7 @@ package io.searchbox.snapshot;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/GetSnapshotRepositoryTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/GetSnapshotRepositoryTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/GetSnapshotTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/GetSnapshotTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/RestoreSnapshotTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/RestoreSnapshotTest.java
@@ -4,7 +4,7 @@ import com.google.gson.Gson;
 import org.elasticsearch.common.settings.Settings;
 import org.junit.Test;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest-common/src/test/java/io/searchbox/snapshot/SnapshotStatusTest.java
+++ b/jest-common/src/test/java/io/searchbox/snapshot/SnapshotStatusTest.java
@@ -4,7 +4,7 @@ import org.junit.Test;
 
 import java.util.Arrays;
 
-import static junit.framework.Assert.assertEquals;
+import static org.junit.Assert.assertEquals;
 
 /**
  * @author happyprg(hongsgo@gmail.com)

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -98,6 +98,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.littleshoot</groupId>
             <artifactId>littleproxy</artifactId>
             <exclusions>

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
@@ -178,7 +178,12 @@ public class JestHttpClientTest {
 
         String query = "{\n" +
                 "    \"query\": {\n" +
-                "        \"term\" : { \"id\" : 1234 }\n" +
+                "        \"bool\" : {\n" +
+                "            \"should\" : [\n" +
+                "                { \"term\" : { \"id\" : 1234 } },\n" +
+                "                { \"term\" : { \"id\" : 567800000000000000000 } }\n" +
+                "            ]\n" +
+                "         }\n" +
                 "     }\n" +
                 "}";
         Search search = new Search.Builder(query)
@@ -198,6 +203,10 @@ public class JestHttpClientTest {
         // Verify payload does not have a double
         assertFalse(payload.contains("1234.0"));
         assertTrue(payload.contains("1234"));
+
+        // Verify payload does not use scientific notation
+        assertFalse(payload.contains("5.678E20"));
+        assertTrue(payload.contains("567800000000000000000"));
     }
 
     @Test

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
@@ -26,7 +26,7 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 
-import static junit.framework.Assert.*;
+import static org.junit.Assert.*;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;

--- a/jest/src/test/java/io/searchbox/core/BulkIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/BulkIntegrationTest.java
@@ -1,21 +1,29 @@
 package io.searchbox.core;
 
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Arrays;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.get.GetRequest;
+import org.elasticsearch.action.get.GetResponse;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+
 import io.searchbox.client.JestResult;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.client.http.JestHttpClient;
 import io.searchbox.common.AbstractIntegrationTest;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-import org.elasticsearch.action.get.GetRequest;
-import org.elasticsearch.action.get.GetResponse;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.text.SimpleDateFormat;
-import java.util.*;
 
 /**
  * @author Dogukan Sonmez
@@ -129,7 +137,7 @@ public class BulkIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void bulkOperationWithIndexWithSourceIncludingWhitespace() throws IOException {
+    public void bulkOperationWithIndexWithSourceIncludingWhitespace() throws IOException, JSONException {
         String index = "twitter";
         String type = "tweet";
         Map<String, String> source1 = new HashMap<String, String>();
@@ -171,7 +179,7 @@ public class BulkIntegrationTest extends AbstractIntegrationTest {
 
         getResponse = client().get(new GetRequest("twitter", "tweet", "2")).actionGet();
         assertNotNull(getResponse);
-        assertEquals(source2, getResponse.getSourceAsString());
+        JSONAssert.assertEquals(source2, getResponse.getSourceAsString(), false);
     }
 
     @Test

--- a/jest/src/test/java/io/searchbox/core/CatIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/CatIntegrationTest.java
@@ -1,12 +1,16 @@
 package io.searchbox.core;
 
-import com.google.gson.JsonArray;
-import io.searchbox.common.AbstractIntegrationTest;
+import java.io.IOException;
+
 import org.elasticsearch.action.admin.indices.alias.IndicesAliasesAction;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
-import java.io.IOException;
+import com.google.gson.JsonArray;
+
+import io.searchbox.common.AbstractIntegrationTest;
 
 /**
  * @author Bartosz Polnik
@@ -25,7 +29,7 @@ public class CatIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void shouldProperlyMapSingleResult() throws IOException {
+    public void shouldProperlyMapSingleResult() throws IOException, JSONException {
         createIndex(INDEX);
         ensureSearchable(INDEX);
 
@@ -34,11 +38,11 @@ public class CatIntegrationTest extends AbstractIntegrationTest {
                 new String[]{"index", "docs.count"},
                 new String[]{INDEX, "0"},
         }, result.getPlainText());
-        assertEquals("[{\"index\":\"catintegrationindex\",\"docs.count\":\"0\"}]", result.getSourceAsString());
+        JSONAssert.assertEquals("[{\"index\":\"catintegrationindex\",\"docs.count\":\"0\"}]", result.getSourceAsString(), false);
     }
 
     @Test
-    public void shouldFilterResultsToASingleIndex() throws IOException {
+    public void shouldFilterResultsToASingleIndex() throws IOException, JSONException {
         createIndex(INDEX, INDEX2);
         ensureSearchable(INDEX, INDEX2);
 
@@ -47,11 +51,11 @@ public class CatIntegrationTest extends AbstractIntegrationTest {
                 new String[]{"index", "docs.count"},
                 new String[]{INDEX2, "0"},
         }, result.getPlainText());
-        assertEquals("[{\"index\":\"catintegrationindex2\",\"docs.count\":\"0\"}]", result.getSourceAsString());
+        JSONAssert.assertEquals("[{\"index\":\"catintegrationindex2\",\"docs.count\":\"0\"}]", result.getSourceAsString(), false);
     }
 
     @Test
-    public void shouldDisplayAliasForSingleResult() throws IOException {
+    public void shouldDisplayAliasForSingleResult() throws IOException, JSONException {
         createIndex(INDEX);
         ensureSearchable(INDEX);
         IndicesAliasesAction.INSTANCE.newRequestBuilder(client().admin().indices()).addAlias(INDEX, ALIAS).get();
@@ -61,11 +65,11 @@ public class CatIntegrationTest extends AbstractIntegrationTest {
                 new String[]{"alias", "index"},
                 new String[]{ALIAS, INDEX},
         }, result.getPlainText());
-        assertEquals("[{\"alias\":\"catintegrationalias\",\"index\":\"catintegrationindex\"}]", result.getSourceAsString());
+        JSONAssert.assertEquals("[{\"alias\":\"catintegrationalias\",\"index\":\"catintegrationindex\"}]", result.getSourceAsString(), false);
     }
 
     @Test
-    public void shouldChangeOrderOfColumnsByspecifyingParameters() throws IOException {
+    public void shouldChangeOrderOfColumnsByspecifyingParameters() throws IOException, JSONException {
         createIndex(INDEX);
         ensureSearchable(INDEX);
         IndicesAliasesAction.INSTANCE.newRequestBuilder(client().admin().indices()).addAlias(INDEX, ALIAS).get();
@@ -75,6 +79,6 @@ public class CatIntegrationTest extends AbstractIntegrationTest {
                 new String[]{"index", "alias"},
                 new String[]{INDEX, ALIAS},
         }, result.getPlainText());
-        assertEquals("[{\"index\":\"catintegrationindex\",\"alias\":\"catintegrationalias\"}]", result.getSourceAsString());
+        JSONAssert.assertEquals("[{\"index\":\"catintegrationindex\",\"alias\":\"catintegrationalias\"}]", result.getSourceAsString(), false);
     }
 }

--- a/jest/src/test/java/io/searchbox/core/GetIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/GetIntegrationTest.java
@@ -1,19 +1,21 @@
 package io.searchbox.core;
 
-import io.searchbox.annotations.JestId;
-import io.searchbox.client.JestResultHandler;
-import io.searchbox.common.AbstractIntegrationTest;
-import org.elasticsearch.action.index.IndexRequest;
-import org.elasticsearch.action.index.IndexResponse;
-import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
+
+import org.elasticsearch.action.index.IndexRequest;
+import org.elasticsearch.action.index.IndexResponse;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.json.JSONException;
+import org.junit.Before;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import io.searchbox.annotations.JestId;
+import io.searchbox.client.JestResultHandler;
+import io.searchbox.common.AbstractIntegrationTest;
 
 /**
  * @author Dogukan Sonmez
@@ -37,7 +39,7 @@ public class GetIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void getWithSpecialCharacterInDocId() throws IOException {
+    public void getWithSpecialCharacterInDocId() throws IOException, JSONException {
         final String documentId = "asd/qwe";
         IndexResponse indexResponse = client().index(new IndexRequest(
                 INDEX,
@@ -55,11 +57,11 @@ public class GetIntegrationTest extends AbstractIntegrationTest {
         assertEquals(INDEX, result.getIndex());
         assertEquals(TYPE, result.getType());
         assertEquals(documentId, result.getId());
-        assertEquals("{\"user\":\"tweety\"}", result.getSourceAsString());
+        JSONAssert.assertEquals("{\"user\":\"tweety\"}", result.getSourceAsString(), false);
     }
 
     @Test
-    public void getAsClass() throws IOException {
+    public void getAsClass() throws IOException, JSONException {
         String id = "900";
         String message = "checkout my lunch guys!";
         Tweet expectedTweet = new Tweet();
@@ -75,7 +77,7 @@ public class GetIntegrationTest extends AbstractIntegrationTest {
         Tweet actualTweet = result.getSourceAsObject(Tweet.class);
         assertEquals(expectedTweet.getMessage(), actualTweet.getMessage());
         assertEquals(expectedTweet.getUserHash(), actualTweet.getUserHash());
-        assertEquals("{\"userHash\":\"900\",\"message\":\"checkout my lunch guys!\"}", result.getSourceAsString());
+        JSONAssert.assertEquals("{\"userHash\":\"900\",\"message\":\"checkout my lunch guys!\"}", result.getSourceAsString(), false);
     }
 
     @Test

--- a/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
@@ -8,6 +8,7 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -62,9 +63,9 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
         List<SearchResult.Hit<Object, Void>> hits = result.getHits(Object.class);
         assertEquals(3, hits.size());
 
-        assertEquals("{\"user\":\"kimchy1\"}," +
+        JSONAssert.assertEquals("{\"user\":\"kimchy1\"}," +
                 "{\"user\":\"kimchy2\"}," +
-                "{\"user\":\"kimchy3\"}", result.getSourceAsString());
+                "{\"user\":\"kimchy3\"}", result.getSourceAsString(), false);
     }
 
     @Test
@@ -74,7 +75,7 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
         refresh();
         ensureSearchable(INDEX);
 
-        SearchResult result = client.execute(new Search.Builder("{\"sort\":[],\"_source\":{\"include\":[\"includeFieldName\"]}}")
+        SearchResult result = client.execute(new Search.Builder("{\"sort\":\"includeFieldName\",\"_source\":{\"include\":[\"includeFieldName\"]}}")
                                                      .addSourceExcludePattern("excludeFieldName").build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
@@ -91,7 +92,7 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
         refresh();
         ensureSearchable(INDEX);
 
-        SearchResult result = client.execute(new Search.Builder("")
+        SearchResult result = client.execute(new Search.Builder("{\"sort\":\"includeFieldName\"}")
                                                      .addSourceIncludePattern("includeFieldName")
                                                      .addSourceExcludePattern("excludeFieldName").build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
@@ -99,7 +100,7 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
         List<SearchResult.Hit<Object, Void>> hits = result.getHits(Object.class);
         assertEquals(2,hits.size());
         assertEquals("{\"includeFieldName\":\"SeoHoo\"}," +
-                     "{\"includeFieldName\":\"Seola\"}",result.getSourceAsString());
+                     "{\"includeFieldName\":\"Seola\"}", result.getSourceAsString());
     }
 
     @Test

--- a/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
@@ -5,7 +5,9 @@ import com.google.gson.JsonArray;
 import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.json.JSONException;
 import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 import java.io.IOException;
 
@@ -25,7 +27,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
     private static final String TYPE = "user";
 
     @Test
-    public void searchWithValidQuery() throws IOException {
+    public void searchWithValidQuery() throws IOException, JSONException {
         assertTrue(index(INDEX, TYPE, "swvq1", "{\"code\":\"0\"}").isCreated());
         assertTrue(index(INDEX, TYPE, "swvq2", "{\"code\":\"1\"}").isCreated());
         assertTrue(index(INDEX, TYPE, "swvq3", "{\"code\":\"2\"}").isCreated());
@@ -57,7 +59,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
                     .setParameter(Parameters.SIZE, 1).build();
             result = client.execute(scroll);
             assertTrue(result.getErrorMessage(), result.isSucceeded());
-            assertEquals("{\"code\":\"" + i + "\"}", result.getSourceAsString());
+            JSONAssert.assertEquals("{\"code\":\"" + i + "\"}", result.getSourceAsString(), false);
             hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
             assertEquals(
                     "only 1 document should be returned",
@@ -83,7 +85,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void clearScrollAll() throws IOException {
+    public void clearScrollAll() throws IOException, JSONException {
         assertTrue(index(INDEX, TYPE, "swvq1", "{\"code\":\"0\"}").isCreated());
         assertTrue(index(INDEX, TYPE, "swvq2", "{\"code\":\"1\"}").isCreated());
         assertTrue(index(INDEX, TYPE, "swvq3", "{\"code\":\"2\"}").isCreated());
@@ -115,7 +117,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
                 .setParameter(Parameters.SIZE, 1).build();
             result = client.execute(scroll);
             assertTrue(result.getErrorMessage(), result.isSucceeded());
-            assertEquals("{\"code\":\"" + i + "\"}", result.getSourceAsString());
+            JSONAssert.assertEquals("{\"code\":\"" + i + "\"}", result.getSourceAsString(), false);
             hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
             assertEquals(
                 "only 1 document should be returned",

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
         <commonsLang.version>3.4</commonsLang.version>
         <commons-io.version>2.5</commons-io.version>
         <junit.version>4.12</junit.version>
+        <jsonassert.version>1.4.0</jsonassert.version>
 
         <plugin.surefire.version>2.19.1</plugin.surefire.version>
         <plugin.sonatype.version>1.6.7</plugin.sonatype.version>
@@ -271,6 +272,13 @@
                         <artifactId>hamcrest-core</artifactId>
                     </exclusion>
                 </exclusions>
+            </dependency>
+
+            <dependency>
+                <groupId>org.skyscreamer</groupId>
+                <artifactId>jsonassert</artifactId>
+                <version>${jsonassert.version}</version>
+                <scope>test</scope>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Hi @ferhatsb !

This is a follow-up of https://github.com/searchbox-io/Jest/pull/405 using a different fix so that it fixes the decimal point **and** the scientific notation.

I recommend to review the commits one by one as the last one introduces a lot of noise:
* First commit is the real fix.
* Second commit improves the existing situation and allows users to use the different syntaxes allowed by ES
* Third commit is a clean up commit to make the build more stable (using jsonassert and query orderning) and removes a lot of deprecated junit.framework imports.

This one is quite critical for us!

Thanks!

-- 
Guillaume