### PR TITLE
Fix #388 - Expose _id in SearchResult.Hit

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -104,6 +104,8 @@ public class SearchResult extends JestResult {
                 String index = hitObject.get("_index").getAsString();
                 String type = hitObject.get("_type").getAsString();
 
+                String id = hitObject.get("_id").getAsString();
+
                 Double score = null;
                 if (hitObject.has("_score") && !hitObject.get("_score").isJsonNull()) {
                     score = hitObject.get("_score").getAsDouble();
@@ -136,6 +138,7 @@ public class SearchResult extends JestResult {
                         sort,
                         index,
                         type,
+                        id,
                         score
                 );
             }
@@ -227,6 +230,7 @@ public class SearchResult extends JestResult {
         public final List<String> sort;
         public final String index;
         public final String type;
+        public final String id;
         public final Double score;
 
         public Hit(Class<T> sourceType, JsonElement source) {
@@ -239,11 +243,11 @@ public class SearchResult extends JestResult {
 
         public Hit(Class<T> sourceType, JsonElement source, Class<K> explanationType, JsonElement explanation,
                    Map<String, List<String>> highlight, List<String> sort) {
-            this(sourceType, source, explanationType, explanation, highlight, sort, null, null, null);
+            this(sourceType, source, explanationType, explanation, highlight, sort, null, null, null, null);
         }
 
         public Hit(Class<T> sourceType, JsonElement source, Class<K> explanationType, JsonElement explanation,
-                   Map<String, List<String>> highlight, List<String> sort, String index, String type, Double score) {
+                   Map<String, List<String>> highlight, List<String> sort, String index, String type, String id, Double score) {
             if (source == null) {
                 this.source = null;
             } else {
@@ -259,6 +263,7 @@ public class SearchResult extends JestResult {
 
             this.index = index;
             this.type = type;
+            this.id = id;
             this.score = score;
         }
 
@@ -271,10 +276,10 @@ public class SearchResult extends JestResult {
         }
 
         public Hit(T source, K explanation, Map<String, List<String>> highlight, List<String> sort) {
-            this(source, explanation, highlight, sort, null, null, null);
+            this(source, explanation, highlight, sort, null, null, null, null);
         }
 
-        public Hit(T source, K explanation, Map<String, List<String>> highlight, List<String> sort, String index, String type, Double score) {
+        public Hit(T source, K explanation, Map<String, List<String>> highlight, List<String> sort, String index, String type, String id, Double score) {
             this.source = source;
             this.explanation = explanation;
             this.highlight = highlight;
@@ -282,6 +287,7 @@ public class SearchResult extends JestResult {
 
             this.index = index;
             this.type = type;
+            this.id = id;
             this.score = score;
         }
 
@@ -292,6 +298,9 @@ public class SearchResult extends JestResult {
                     .append(explanation)
                     .append(highlight)
                     .append(sort)
+                    .append(index)
+                    .append(type)
+                    .append(id)
                     .toHashCode();
         }
 
@@ -313,6 +322,9 @@ public class SearchResult extends JestResult {
                     .append(explanation, rhs.explanation)
                     .append(highlight, rhs.highlight)
                     .append(sort, rhs.sort)
+                    .append(index, rhs.index)
+                    .append(type, rhs.type)
+                    .append(id, rhs.id)
                     .isEquals();
         }
     }

--- a/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
@@ -165,6 +165,7 @@ public class SearchResultTest {
         assertNotNull(hit.source);
         assertNull(hit.explanation);
         assertNotNull(hit.sort);
+        assertNotNull(hit.id);
         assertNull(hit.score);
 
         hit = searchResult.getFirstHit(Object.class, Object.class);
@@ -172,6 +173,7 @@ public class SearchResultTest {
         assertNotNull(hit.source);
         assertNull(hit.explanation);
         assertNotNull(hit.sort);
+        assertNotNull(hit.id);
         assertNull(hit.score);
     }
 
@@ -200,7 +202,7 @@ public class SearchResultTest {
         hit = searchResult.getFirstHit(Object.class, Object.class);
         assertNull(hit);
     }
-    
+
     @Test
     public void testGetScore() {
         String jsonWithScore = "{\n" +
@@ -229,7 +231,7 @@ public class SearchResultTest {
                 "        ]\n" +
                 "    }\n" +
                 "}";
-        
+
         SearchResult searchResult = new SearchResult(new Gson());
         searchResult.setSucceeded(true);
         searchResult.setJsonString(jsonWithScore);
@@ -241,6 +243,7 @@ public class SearchResultTest {
         assertNotNull(hit.source);
         assertNull(hit.explanation);
         assertNotNull(hit.sort);
+        assertNotNull(hit.id);
         assertNotNull(hit.score);
 
         hit = searchResult.getFirstHit(Object.class, Object.class);
@@ -248,6 +251,7 @@ public class SearchResultTest {
         assertNotNull(hit.source);
         assertNull(hit.explanation);
         assertNotNull(hit.sort);
+        assertNotNull(hit.id);
         assertNotNull(hit.score);
     }
 

--- a/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
@@ -62,6 +62,10 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
         List<SearchResult.Hit<Object, Void>> hits = result.getHits(Object.class);
         assertEquals(3, hits.size());
 
+        assertEquals(hits.get(0).id, "swmh1");
+        assertEquals(hits.get(1).id, "swmh2");
+        assertEquals(hits.get(2).id, "swmh3");
+
         assertEquals("{\"user\":\"kimchy1\"}," +
                 "{\"user\":\"kimchy2\"}," +
                 "{\"user\":\"kimchy3\"}", result.getSourceAsString());


### PR DESCRIPTION
Fix for https://github.com/searchbox-io/Jest/issues/388