### PR TITLE
Add MultiGet support for "routing" and "search_type"

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
@@ -55,6 +55,8 @@ public class MultiSearch extends AbstractAction<MultiSearchResult> {
             sb.append(getParameter(search, "ignore_unavailable"));
             sb.append(getParameter(search, "allow_no_indices"));
             sb.append(getParameter(search, "expand_wildcards"));
+            sb.append(getParameter(search, "routing"));
+            sb.append(getParameter(search, "search_type"));
             sb.append("\"}\n")
                     .append(search.getData(gson))
                     .append("\n");

--- a/jest-common/src/test/java/io/searchbox/core/MultiSearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/MultiSearchTest.java
@@ -1,5 +1,7 @@
 package io.searchbox.core;
 
+import io.searchbox.params.Parameters;
+import io.searchbox.params.SearchType;
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -50,6 +52,27 @@ public class MultiSearchTest {
                 "{\"query\" : {\"match_all\" : {}}}\n";
         Search search = new Search.Builder("{\"query\" : {\"match_all\" : {}}}")
                 .addIndex("twitter")
+                .build();
+        Search search2 = new Search.Builder("{\"query\" : {\"match_all\" : {}}}").build();
+
+        MultiSearch multiSearch = new MultiSearch.Builder(search).addSearch(search2).build();
+
+        assertEquals("POST", multiSearch.getRestMethodName());
+        assertEquals("/_msearch", multiSearch.getURI());
+        JSONAssert.assertEquals(expectedData, multiSearch.getData(null).toString(), false);
+    }
+
+    @Test
+    public void multiSearchWithExtraParameters() throws JSONException {
+        String expectedData = " {\"index\" : \"twitter\", \"search_type\" : \"query_then_fetch\", \"routing\" : \"testRoute\", \"ignore_unavailable\" : \"true\", \"allow_no_indices\" : \"true\", \"expand_wildcards\" : \"true\"}\n" +
+                "{\"query\" : {\"match_all\" : {}}}\n";
+        Search search = new Search.Builder("{\"query\" : {\"match_all\" : {}}}")
+                .addIndex("twitter")
+                .setParameter(Parameters.ROUTING, "testRoute")
+                .setSearchType(SearchType.QUERY_THEN_FETCH)
+                .setParameter(Parameters.IGNORE_UNAVAILABLE, true)
+                .setParameter(Parameters.ALLOW_NO_INDICES, true)
+                .setParameter("expand_wildcards", true)
                 .build();
         Search search2 = new Search.Builder("{\"query\" : {\"match_all\" : {}}}").build();
 


### PR DESCRIPTION
`MultiSearch` requests ignore the "routing" and "search_type" parameters given to each `Search` request object. This request expands on a previous pull-request to add support for additional parameters.