### PR TITLE
Fix node discovery for elasticsearch 5

### DIFF
--- a/jest-common/src/test/java/io/searchbox/client/config/discovery/NodeCheckerTest.java
+++ b/jest-common/src/test/java/io/searchbox/client/config/discovery/NodeCheckerTest.java
@@ -331,4 +331,29 @@ public class NodeCheckerTest {
         assertEquals(0, nodeChecker.discoveredServerList.size());
 	}
 
+    @Test
+    public void testWithPublishAddress() throws Exception {
+        JestResult result = new JestResult(new Gson());
+        result.setJsonMap(ImmutableMap.<String, Object>of(
+            "ok", "true",
+            "nodes", ImmutableMap.of(
+                "node_name", ImmutableMap.of(
+                    "http", ImmutableMap.of(
+                        "publish_address", "192.168.2.10:9200"
+                    )
+                )
+            )
+        ));
+        result.setSucceeded(true);
+        when(jestClient.execute(isA(Action.class))).thenReturn(result);
+
+        NodeChecker nodeChecker = new NodeChecker(jestClient, clientConfig);
+        nodeChecker.runOneIteration();
+
+        ArgumentCaptor<LinkedHashSet> argument = ArgumentCaptor.forClass(LinkedHashSet.class);
+        verify(jestClient).setServers(argument.capture());
+
+        Set servers = argument.getValue();
+        assertEquals("http://192.168.2.10:9200", servers.iterator().next());
+    }
 }


### PR DESCRIPTION
This pull request is associated with #440 and #409 .

In elasticsearch 5 the http_address field as been removed and been replaced with publish_address.
For reference: https://github.com/elastic/elasticsearch/issues/21292

With this change the server address can be resolved when using elasticsearch 5 and node_discovery.