### PR TITLE
Reroute endpoints

### DIFF
--- a/jest-common/src/main/java/io/searchbox/cluster/Reroute.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/Reroute.java
@@ -1,0 +1,64 @@
+package io.searchbox.cluster;
+
+import com.google.common.collect.ImmutableMap;
+import io.searchbox.action.AbstractAction;
+import io.searchbox.action.GenericResultAbstractAction;
+import io.searchbox.cluster.reroute.RerouteCommand;
+
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+public class Reroute extends GenericResultAbstractAction {
+
+    protected Reroute(Builder builder) {
+        super(builder);
+        setURI(buildURI());
+
+        List<Map> actions = new LinkedList<>();
+        for (RerouteCommand rerouteCommand : builder.commandList) {
+            String type = rerouteCommand.getType();
+            Map<String, Object> data = rerouteCommand.getData();
+            actions.add(ImmutableMap.of(type, data));
+        }
+        this.payload = ImmutableMap.<String, Object>of("commands", actions);
+    }
+
+    @Override
+    protected String buildURI() {
+        return super.buildURI() + "/_cluster/reroute";
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "POST";
+    }
+
+    public static class Builder extends AbstractAction.Builder<Reroute, Builder> {
+        private List<RerouteCommand> commandList = new LinkedList<>();
+
+        public Builder(RerouteCommand rerouteCommand) {
+            commandList.add(rerouteCommand);
+        }
+
+        public Builder(Collection<RerouteCommand> rerouteCommands) {
+            commandList.addAll(rerouteCommands);
+        }
+
+        public Builder addCommand(RerouteCommand rerouteCommand) {
+            commandList.add(rerouteCommand);
+            return this;
+        }
+
+        public Builder addCommands(Collection<RerouteCommand> rerouteCommands) {
+            commandList.addAll(rerouteCommands);
+            return this;
+        }
+
+        @Override
+        public Reroute build() {
+            return new Reroute(this);
+        }
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteAllocate.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteAllocate.java
@@ -1,0 +1,37 @@
+package io.searchbox.cluster.reroute;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RerouteAllocate implements RerouteCommand {
+
+    private final String index;
+    private final int shard;
+    private final String node;
+    private final boolean allowPrimary;
+
+    public RerouteAllocate(String index, int shard, String node, boolean allowPrimary) {
+        this.index = index;
+        this.shard = shard;
+        this.node = node;
+        this.allowPrimary = allowPrimary;
+    }
+
+    @Override
+    public String getType() {
+        return "allocate";
+    }
+
+    @Override
+    public Map<String, Object> getData() {
+        Map<String, Object> paramsMap = new LinkedHashMap<>();
+
+        paramsMap.put("index", index);
+        paramsMap.put("shard", shard);
+        paramsMap.put("node", node);
+        paramsMap.put("allow_primary", allowPrimary);
+
+        return paramsMap;
+    }
+
+}

--- a/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteCancel.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteCancel.java
@@ -1,0 +1,36 @@
+package io.searchbox.cluster.reroute;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RerouteCancel implements RerouteCommand {
+
+    private final String index;
+    private final int shard;
+    private final String node;
+    private final boolean allowPrimary;
+
+    public RerouteCancel(String index, int shard, String node, boolean allowPrimary) {
+        this.index = index;
+        this.shard = shard;
+        this.node = node;
+        this.allowPrimary = allowPrimary;
+    }
+
+    @Override
+    public String getType() {
+        return "cancel";
+    }
+
+    @Override
+    public Map<String, Object> getData() {
+        Map<String, Object> paramsMap = new LinkedHashMap<>();
+
+        paramsMap.put("index", index);
+        paramsMap.put("shard", shard);
+        paramsMap.put("node", node);
+        paramsMap.put("allow_primary", allowPrimary);
+
+        return paramsMap;
+    }
+}

--- a/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteCommand.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteCommand.java
@@ -1,0 +1,9 @@
+package io.searchbox.cluster.reroute;
+
+import java.util.Map;
+
+public interface RerouteCommand {
+    String getType();
+
+    Map<String, Object> getData();
+}

--- a/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteMove.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/reroute/RerouteMove.java
@@ -1,0 +1,37 @@
+package io.searchbox.cluster.reroute;
+
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public class RerouteMove implements RerouteCommand {
+
+    private final String index;
+    private final int shard;
+    private final String fromNode;
+    private final String toNode;
+
+    public RerouteMove(String index, int shard, String fromNode, String toNode) {
+        this.index = index;
+        this.shard = shard;
+        this.fromNode = fromNode;
+        this.toNode = toNode;
+    }
+
+    @Override
+    public String getType() {
+        return "move";
+    }
+
+    @Override
+    public Map<String, Object> getData() {
+        Map<String, Object> paramsMap = new LinkedHashMap<String, Object>();
+        paramsMap.put("index", index);
+        paramsMap.put("shard", shard);
+        paramsMap.put("from_node", fromNode);
+        paramsMap.put("to_node", toNode);
+
+        return paramsMap;
+    }
+
+}

--- a/jest-common/src/main/java/io/searchbox/core/Cat.java
+++ b/jest-common/src/main/java/io/searchbox/core/Cat.java
@@ -9,6 +9,7 @@ import com.google.gson.JsonSyntaxException;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
@@ -90,6 +91,51 @@ public class Cat extends AbstractAction<CatResult> {
     public static class AliasesBuilder extends AbstractMultiIndexActionBuilder<Cat, AliasesBuilder> implements CatBuilder {
         private static final String operationPath = "aliases";
         public AliasesBuilder() {
+            setHeader("accept", "application/json");
+            setHeader("content-type", "application/json");
+        }
+
+        @Override
+        public Cat build() {
+            return new Cat(this);
+        }
+
+        @Override
+        public String operationPath() {
+            return operationPath;
+        }
+    }
+
+    public static class ShardsBuilder extends AbstractMultiIndexActionBuilder<Cat, ShardsBuilder> implements CatBuilder {
+        private static final String operationPath = "shards";
+        public ShardsBuilder() {
+            setHeader("accept", "application/json");
+            setHeader("content-type", "application/json");
+        }
+
+        @Override
+        public Cat build() {
+            return new Cat(this);
+        }
+
+        @Override
+        public String operationPath() {
+            return operationPath;
+        }
+
+        @Override
+        public String getJoinedIndices() {
+            if (indexNames.size() > 0) {
+                return StringUtils.join(indexNames, ",");
+            } else {
+                return null;
+            }
+        }
+    }
+
+    public static class NodesBuilder extends AbstractAction.Builder<Cat, NodesBuilder> implements CatBuilder {
+        private static final String operationPath = "nodes";
+        public NodesBuilder() {
             setHeader("accept", "application/json");
             setHeader("content-type", "application/json");
         }

--- a/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
@@ -1,0 +1,34 @@
+package io.searchbox.cluster;
+
+import com.google.gson.Gson;
+import io.searchbox.cluster.reroute.RerouteMove;
+import io.searchbox.cluster.reroute.RerouteCommand;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class RerouteTest {
+
+    @Test
+    public void reroute() throws JSONException {
+        List<RerouteCommand> moveCommands = new LinkedList<RerouteCommand>();
+        moveCommands.add(new RerouteMove("index1", 1, "node1", "node2"));
+        moveCommands.add(new RerouteMove("index2", 1, "node2", "node1"));
+
+        Reroute reroute = new Reroute.Builder(moveCommands).build();
+        assertEquals("/_cluster/reroute", reroute.getURI());
+        assertEquals("POST", reroute.getRestMethodName());
+
+        String expectedData = "{ \"commands\": [" +
+                "{ \"move\": { \"index\": \"index1\", \"shard\": 1, \"from_node\": \"node1\", \"to_node\": \"node2\" } }, " +
+                "{ \"move\": { \"index\": \"index2\", \"shard\": 1, \"from_node\": \"node2\", \"to_node\": \"node1\" } }" +
+                "] }";
+        JSONAssert.assertEquals(expectedData, reroute.getData(new Gson()), false);
+    }
+
+}

--- a/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
@@ -1,6 +1,8 @@
 package io.searchbox.cluster;
 
 import com.google.gson.Gson;
+import io.searchbox.cluster.reroute.RerouteAllocate;
+import io.searchbox.cluster.reroute.RerouteCancel;
 import io.searchbox.cluster.reroute.RerouteMove;
 import io.searchbox.cluster.reroute.RerouteCommand;
 import org.json.JSONException;
@@ -18,7 +20,8 @@ public class RerouteTest {
     public void reroute() throws JSONException {
         List<RerouteCommand> moveCommands = new LinkedList<RerouteCommand>();
         moveCommands.add(new RerouteMove("index1", 1, "node1", "node2"));
-        moveCommands.add(new RerouteMove("index2", 1, "node2", "node1"));
+        moveCommands.add(new RerouteCancel("index2", 1, "node2", true));
+        moveCommands.add(new RerouteAllocate("index3", 1, "node3", false));
 
         Reroute reroute = new Reroute.Builder(moveCommands).build();
         assertEquals("/_cluster/reroute", reroute.getURI());
@@ -26,7 +29,8 @@ public class RerouteTest {
 
         String expectedData = "{ \"commands\": [" +
                 "{ \"move\": { \"index\": \"index1\", \"shard\": 1, \"from_node\": \"node1\", \"to_node\": \"node2\" } }, " +
-                "{ \"move\": { \"index\": \"index2\", \"shard\": 1, \"from_node\": \"node2\", \"to_node\": \"node1\" } }" +
+                "{ \"cancel\": { \"index\": \"index2\", \"shard\": 1, \"node\": \"node2\", \"allow_primary\": true } }," +
+                "{ \"allocate\": { \"index\": \"index3\", \"shard\": 1, \"node\": \"node3\", \"allow_primary\": false } }" +
                 "] }";
         JSONAssert.assertEquals(expectedData, reroute.getData(new Gson()), false);
     }

--- a/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteAllocateTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteAllocateTest.java
@@ -1,0 +1,34 @@
+package io.searchbox.cluster.reroute;
+
+import com.google.gson.Gson;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.Assert.*;
+
+public class RerouteAllocateTest {
+
+    @Test
+    public void allowPrimaryTrue() throws JSONException {
+        RerouteAllocate allocateReplica = new RerouteAllocate("index1", 1, "node1", true);
+
+        assertEquals(allocateReplica.getType(), "allocate");
+
+        String actualJson = new Gson().toJson(allocateReplica.getData());
+        String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": true}";
+        JSONAssert.assertEquals(actualJson, expectedJson, false);
+    }
+
+    @Test
+    public void allowPrimaryFalse() throws JSONException {
+        RerouteAllocate allocateReplica = new RerouteAllocate("index1", 1, "node1", false);
+
+        assertEquals(allocateReplica.getType(), "allocate");
+
+        String actualJson = new Gson().toJson(allocateReplica.getData());
+        String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": false}";
+        JSONAssert.assertEquals(actualJson, expectedJson, false);
+    }
+
+}

--- a/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteCancelTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteCancelTest.java
@@ -1,0 +1,34 @@
+package io.searchbox.cluster.reroute;
+
+import com.google.gson.Gson;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.Assert.*;
+
+public class RerouteCancelTest {
+
+    @Test
+    public void allowPrimaryTrue() throws JSONException {
+        RerouteCancel rerouteCancel = new RerouteCancel("index1", 1, "node1", true);
+
+        assertEquals(rerouteCancel.getType(), "cancel");
+
+        String actualJson = new Gson().toJson(rerouteCancel.getData());
+        String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": true}";
+        JSONAssert.assertEquals(actualJson, expectedJson, false);
+    }
+
+    @Test
+    public void allowPrimaryFalse() throws JSONException {
+        RerouteCancel rerouteCancel = new RerouteCancel("index1", 1, "node1", false);
+
+        assertEquals(rerouteCancel.getType(), "cancel");
+
+        String actualJson = new Gson().toJson(rerouteCancel.getData());
+        String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": false}";
+        JSONAssert.assertEquals(actualJson, expectedJson, false);
+    }
+
+}

--- a/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteMoveTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteMoveTest.java
@@ -1,0 +1,23 @@
+package io.searchbox.cluster.reroute;
+
+import com.google.gson.Gson;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+import static org.junit.Assert.*;
+
+public class RerouteMoveTest {
+
+    @Test
+    public void move() throws JSONException {
+        RerouteMove rerouteMove = new RerouteMove("index1", 1, "node1", "node2");
+
+        assertEquals(rerouteMove.getType(), "move");
+
+        String actualJson = new Gson().toJson(rerouteMove.getData());
+        String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"from_node\": \"node1\", \"to_node\": \"node2\"}";
+        JSONAssert.assertEquals(actualJson, expectedJson, false);
+    }
+
+}

--- a/jest-common/src/test/java/io/searchbox/core/CatNodesBuilderTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/CatNodesBuilderTest.java
@@ -1,0 +1,26 @@
+package io.searchbox.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CatNodesBuilderTest {
+    @Test
+    public void shouldSetApplicationJsonHeader() {
+        Cat cat = new Cat.NodesBuilder().build();
+        assertEquals("application/json", cat.getHeader("accept"));
+        assertEquals("application/json", cat.getHeader("content-type"));
+    }
+
+    @Test
+    public void shouldGenerateValidUriWhenIndexNotGiven() {
+        Cat cat = new Cat.NodesBuilder().build();
+        assertEquals("_cat/nodes", cat.getURI());
+    }
+
+    @Test
+    public void shouldGenerateValidUriWhenParameterGiven() {
+        Cat cat = new Cat.NodesBuilder().setParameter("v", "true").build();
+        assertEquals("_cat/nodes?v=true", cat.getURI());
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/core/CatShardsBuilderTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/CatShardsBuilderTest.java
@@ -1,0 +1,32 @@
+package io.searchbox.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class CatShardsBuilderTest {
+    @Test
+    public void shouldSetApplicationJsonHeader() {
+        Cat cat = new Cat.ShardsBuilder().build();
+        assertEquals("application/json", cat.getHeader("accept"));
+        assertEquals("application/json", cat.getHeader("content-type"));
+    }
+
+    @Test
+    public void shouldGenerateValidUriWhenIndexNotGiven() {
+        Cat cat = new Cat.ShardsBuilder().build();
+        assertEquals("_cat/shards", cat.getURI());
+    }
+
+    @Test
+    public void shouldGenerateValidUriWhenIndexGiven() {
+        Cat cat = new Cat.ShardsBuilder().addIndex("testIndex").build();
+        assertEquals("_cat/shards/testIndex", cat.getURI());
+    }
+
+    @Test
+    public void shouldGenerateValidUriWhenParameterGiven() {
+        Cat cat = new Cat.ShardsBuilder().setParameter("v", "true").build();
+        assertEquals("_cat/shards?v=true", cat.getURI());
+    }
+}

--- a/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
@@ -69,7 +69,7 @@ public class RerouteIntegrationTest extends AbstractIntegrationTest {
         JestResult result = client.execute(new Reroute.Builder(commands).build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
-        // Wait for shard to be cancelled
+        // Wait for shard to be cancelled and reallocated
         Thread.sleep(1000);
         assertEquals(getNodeOfPrimaryShard(INDEX, shardToReroute), toNode);
     }

--- a/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
@@ -1,0 +1,148 @@
+package io.searchbox.cluster;
+
+import com.google.common.collect.ImmutableList;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestResult;
+import io.searchbox.cluster.reroute.RerouteAllocate;
+import io.searchbox.cluster.reroute.RerouteCancel;
+import io.searchbox.cluster.reroute.RerouteCommand;
+import io.searchbox.cluster.reroute.RerouteMove;
+import io.searchbox.common.AbstractIntegrationTest;
+import io.searchbox.core.Cat;
+import io.searchbox.core.CatResult;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set ;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 3)
+public class RerouteIntegrationTest extends AbstractIntegrationTest {
+
+    static final String INDEX = "reroute";
+
+    @Before
+    public void beforeTest() throws IOException {
+        createIndex(INDEX);
+        ensureSearchable(INDEX);
+        setAllocationDisabled(true);
+    }
+
+    @After
+    public void afterTest() throws IOException {
+        setAllocationDisabled(false);
+    }
+
+    @Test
+    public void move() throws IOException, InterruptedException {
+        int shardToReroute = 0;
+
+        String fromNode = getNodeOfPrimaryShard(INDEX, shardToReroute);
+        String toNode = getAvailableNodeForShard(INDEX, shardToReroute);
+
+        RerouteMove rerouteMove = new RerouteMove(INDEX, shardToReroute, fromNode, toNode);
+        JestResult result = client.execute(new Reroute.Builder(rerouteMove).build());
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        // Wait for shard to be moved
+        Thread.sleep(1000);
+        assertEquals(getNodeOfPrimaryShard(INDEX, shardToReroute), toNode);
+    }
+
+    @Test
+    public void cancelAndAllocate() throws IOException, InterruptedException {
+        int shardToReroute = 0;
+
+        String fromNode = getNodeOfPrimaryShard(INDEX, shardToReroute);
+        String toNode = getAvailableNodeForShard(INDEX, shardToReroute);
+
+        List<RerouteCommand> commands = ImmutableList.of(
+                new RerouteCancel(INDEX, shardToReroute, fromNode, true),
+                new RerouteAllocate(INDEX, shardToReroute, toNode, true)
+        );
+        JestResult result = client.execute(new Reroute.Builder(commands).build());
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        // Wait for shard to be cancelled
+        Thread.sleep(1000);
+        assertEquals(getNodeOfPrimaryShard(INDEX, shardToReroute), toNode);
+    }
+
+    private void setAllocationDisabled(boolean disabled) throws IOException {
+        String source = "{\n" +
+                "    \"transient\" : {\n" +
+                "        \"cluster.routing.allocation.disable_allocation\": \"" + disabled + "\" " +
+                "    }\n" +
+                "}";
+
+        UpdateSettings updateSettings = new UpdateSettings.Builder(source).build();
+        JestResult result = client.execute(updateSettings);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+    }
+
+    private String getAvailableNodeForShard(String index, int shard) throws IOException {
+        Set<String> dataNodes = getAllDataNodes();
+
+        String primaryShardNode = getNodeOfPrimaryShard(index, shard);
+        Set<String> replicaShardNodes = getNodesOfReplicaShard(index, shard);
+        dataNodes.remove(primaryShardNode);
+        dataNodes.removeAll(replicaShardNodes);
+
+        if (dataNodes.size() < 1) {
+            throw new RuntimeException("No Available node for shard=" + shard + " index=" + index);
+        }
+
+        return dataNodes.iterator().next();
+    }
+
+    private Set<String> getAllDataNodes() throws IOException {
+        CatResult result = client.execute(new Cat.NodesBuilder().build());
+        JsonArray nodes = result.getJsonObject().get("result").getAsJsonArray();
+
+        Set<String> nodeNames = new HashSet<String>();
+        for (JsonElement nodeElement : nodes) {
+            JsonObject nodeObj = nodeElement.getAsJsonObject();
+            String nodeRole = nodeObj.get("node.role").getAsString();
+            if (nodeRole.indexOf('d') >= 0) {
+                nodeNames.add(nodeObj.get("name").getAsString());
+            }
+        }
+
+        return nodeNames;
+    }
+
+    private String getNodeOfPrimaryShard(String index, int shard) throws IOException {
+        Set<String> nodeOfShard = getNodeOfShard(index, shard, true);
+        if (nodeOfShard.size() == 0) {
+            return null;
+        }
+        return nodeOfShard.iterator().next();
+    }
+
+    private Set<String> getNodesOfReplicaShard(String index, int shard) throws IOException {
+        return getNodeOfShard(index, shard, false);
+    }
+
+    private Set<String> getNodeOfShard(String index, int shard, boolean isPrimary) throws IOException {
+        char prirep = isPrimary ? 'p' : 'r';
+        CatResult result = client.execute(new Cat.ShardsBuilder().addIndex(index).setParameter("h", "shard,node,prirep").build());
+        JsonArray shards = result.getJsonObject().get("result").getAsJsonArray();
+
+        Set<String> resultSet = new HashSet<>();
+        for (JsonElement shardElement : shards) {
+            JsonObject shardObj = shardElement.getAsJsonObject();
+            if (shardObj.get("shard").getAsInt() == shard && shardObj.get("prirep").getAsCharacter() == prirep) {
+                resultSet.add(shardObj.get("node").getAsString());
+            }
+        }
+
+        return resultSet;
+    }
+
+}


### PR DESCRIPTION
Support ES reroute endpoints (https://www.elastic.co/guide/en/elasticsearch/reference/2.4/cluster-reroute.html)

*This pull request uses cat-shards and cat-nodes (PR #448) for integration tests