### PR TITLE
Replaced .addType("tweet") by .addIndex("tweet")

### DIFF
--- a/jest/README.md
+++ b/jest/README.md
@@ -298,7 +298,7 @@ String query = "{\n" +
 Search search = new Search.Builder(query)
                 // multiple index or types can be added.
                 .addIndex("twitter")
-                .addIndex("tweet")
+                .addType("tweet")
                 .build();
 
 SearchResult result = client.execute(search);
@@ -316,7 +316,7 @@ String query = "{\n" +
 Search search = new Search.TemplateBuilder(query)
                 // multiple index or types can be added.
                 .addIndex("twitter")
-                .addIndex("tweet")
+                .addType("tweet")
                 .build();
 
 SearchResult result = client.execute(search);
@@ -332,7 +332,7 @@ searchSourceBuilder.query(QueryBuilders.matchQuery("user", "kimchy"));
 Search search = new Search.Builder(searchSourceBuilder.toString())
                                 // multiple index or types can be added.
                                 .addIndex("twitter")
-                                .addIndex("tweet")
+                                .addType("tweet")
                                 .build();
 
 SearchResult result = client.execute(search);


### PR DESCRIPTION
Corrected the Documentation. The examples with the copy/paste error were really confusing for a newbie in indexes / types. In the doc, the index is "twitter" and the type is "tweet".