### PR TITLE
Clarifying the importance of setting conn limits

### DIFF
--- a/jest/README.md
+++ b/jest/README.md
@@ -90,6 +90,10 @@ Start using Jest by simply creating a `JestClient` instance:
  factory.setHttpClientConfig(new HttpClientConfig
                         .Builder("http://localhost:9200")
                         .multiThreaded(true)
+			//Per default this implementation will create no more than 2 concurrent connections per given route
+			.defaultMaxTotalConnectionPerRoute(<YOUR_DESIRED_LEVEL_OF_CONCURRENCY_PER_ROUTE>)
+			// and no more 20 connections in total
+			.maxTotalConnection(<YOUR_DESIRED_LEVEL_OF_CONCURRENCY_TOTAL>)
                         .build());
  JestClient client = factory.getObject();
 ```


### PR DESCRIPTION
I cursed Jest's concurrency for a whole day before finding this out

Comment content extracted from "http://hc.apache.org/httpcomponents-asyncclient-dev/httpasyncclient/apidocs/org/apache/http/impl/nio/conn/PoolingNHttpClientConnectionManager.html"