### PR TITLE
Fix RerouteAllocateReplicaTest and RerouteTest

### DIFF
--- a/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/RerouteTest.java
@@ -30,7 +30,7 @@ public class RerouteTest {
         String expectedData = "{ \"commands\": [" +
                 "{ \"move\": { \"index\": \"index1\", \"shard\": 1, \"from_node\": \"node1\", \"to_node\": \"node2\" } }, " +
                 "{ \"cancel\": { \"index\": \"index2\", \"shard\": 1, \"node\": \"node2\", \"allow_primary\": true } }," +
-                "{ \"allocate\": { \"index\": \"index3\", \"shard\": 1, \"node\": \"node3\", \"allow_primary\": false } }" +
+                "{ \"allocate_replica\": { \"index\": \"index3\", \"shard\": 1, \"node\": \"node3\" } }" +
                 "] }";
         JSONAssert.assertEquals(expectedData, reroute.getData(new Gson()), false);
     }

--- a/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteAllocateReplicaTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/reroute/RerouteAllocateReplicaTest.java
@@ -13,7 +13,7 @@ public class RerouteAllocateReplicaTest {
     public void allowPrimaryTrue() throws JSONException {
         RerouteAllocateReplica allocateReplica = new RerouteAllocateReplica("index1", 1, "node1");
 
-        assertEquals(allocateReplica.getType(), "allocate");
+        assertEquals(allocateReplica.getType(), "allocate_replica");
 
         String actualJson = new Gson().toJson(allocateReplica.getData());
         String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": true}";
@@ -24,7 +24,7 @@ public class RerouteAllocateReplicaTest {
     public void allowPrimaryFalse() throws JSONException {
         RerouteAllocateReplica allocateReplica = new RerouteAllocateReplica("index1", 1, "node1");
 
-        assertEquals(allocateReplica.getType(), "allocate");
+        assertEquals(allocateReplica.getType(), "allocate_replica");
 
         String actualJson = new Gson().toJson(allocateReplica.getData());
         String expectedJson = "{\"index\":\"index1\", \"shard\": 1, \"node\": \"node1\", \"allow_primary\": false}";


### PR DESCRIPTION
The setting "allocate" was renamed to "allocate_replica".

Refs https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking_50_allocation.html#_reroute_commands