### PR TITLE
Replace HTTP GET requests with body by POST requests

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Explain.java
+++ b/jest-common/src/main/java/io/searchbox/core/Explain.java
@@ -18,7 +18,7 @@ public class Explain extends SingleResultAbstractDocumentTargetedAction {
 
     @Override
     public String getRestMethodName() {
-        return "GET";
+        return "POST";
     }
 
     @Override

--- a/jest-common/src/main/java/io/searchbox/core/MultiGet.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiGet.java
@@ -50,7 +50,7 @@ public class MultiGet extends GenericResultAbstractAction {
 
     @Override
     public String getRestMethodName() {
-        return "GET";
+        return "POST";
     }
 
     @Override

--- a/jest-common/src/test/java/io/searchbox/core/ExplainTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/ExplainTest.java
@@ -13,7 +13,7 @@ public class ExplainTest {
     @Test
     public void explain() {
         Explain explain = new Explain.Builder("twitter", "tweet", "1", "query").build();
-        assertEquals("GET", explain.getRestMethodName());
+        assertEquals("POST", explain.getRestMethodName());
         assertEquals("twitter/tweet/1/_explain", explain.getURI());
         assertEquals("query", explain.getData(null));
     }

--- a/jest-common/src/test/java/io/searchbox/core/MultiGetTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/MultiGetTest.java
@@ -24,7 +24,7 @@ public class MultiGetTest {
     public void getMultipleDocs() throws JSONException {
         MultiGet get = new MultiGet.Builder.ByDoc(Arrays.asList(doc1, doc2, doc3)).build();
 
-        assertEquals("GET", get.getRestMethodName());
+        assertEquals("POST", get.getRestMethodName());
         assertEquals("/_mget", get.getURI());
         JSONAssert.assertEquals("{\"docs\":[" +
                 "{\"_index\":\"twitter\",\"_type\":\"tweet\",\"_id\":\"1\"}," +
@@ -53,7 +53,7 @@ public class MultiGetTest {
     public void getDocumentWithMultipleIds() throws JSONException {
         MultiGet get = new MultiGet.Builder.ById("twitter", "tweet").addId(Arrays.asList("1", "2", "3")).build();
 
-        assertEquals("GET", get.getRestMethodName());
+        assertEquals("POST", get.getRestMethodName());
         assertEquals("twitter/tweet/_mget", get.getURI());
         JSONAssert.assertEquals("{\"ids\":[\"1\",\"2\",\"3\"]}", get.getData(new Gson()), false);
     }


### PR DESCRIPTION
While HTTP GET requests with body are not exactly forbidden by [RFC 2616](https://www.ietf.org/rfc/rfc2616.txt),
at least their semantics isn't clearly defined and some HTTP clients and
proxies refuse to process GET requests with a body payload.

Fortunately Elasticsearch supports using **POST** instead of **GET** for the relevant
requests, [Multi GET](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html) and [Explain](https://www.elastic.co/guide/en/elasticsearch/reference/5.3/search-request-explain.html), yielding the same result.

References:

* https://tools.ietf.org/html/rfc7231#section-4.3.1
* https://stackoverflow.com/questions/978061/http-get-with-request-body