### PR TITLE
Use Oracle JDK8 on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
 language: java
+jdk:
+  - oraclejdk8
 sudo: false
 env:
   global:


### PR DESCRIPTION
Commit 23eb0dc764d58921bedf3348006cc944689d06a0 switched the Maven build from Java 7 to Java 8 but Travis CI will still use Java 7 without being explicitly told to use Oracle JDK8.