### PR TITLE
Upgrade to Elasticsearch 5.3.0

### DIFF
--- a/jest-common/src/main/java/io/searchbox/cluster/NodesStats.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/NodesStats.java
@@ -100,13 +100,6 @@ public class NodesStats extends GenericResultAbstractAction {
             return addCleanApiParameter("transport");
         }
 
-        /**
-         * Clears all the flags (first). Useful, if you only want to retrieve specific stats
-         */
-        public Builder withClear() {
-            return addCleanApiParameter("clear");
-        }
-
         @Override
         public NodesStats build() {
             return new NodesStats(this);

--- a/jest-common/src/main/java/io/searchbox/core/Search.java
+++ b/jest-common/src/main/java/io/searchbox/core/Search.java
@@ -104,8 +104,8 @@ public class Search extends AbstractAction<SearchResult> {
             if (!includePatternList.isEmpty() || !excludePatternList.isEmpty()) {
                 JsonObject sourceObject = normalizeSourceClause(queryObject);
 
-                addPatternListToSource(sourceObject, "include", includePatternList);
-                addPatternListToSource(sourceObject, "exclude", excludePatternList);
+                addPatternListToSource(sourceObject, "includes", includePatternList);
+                addPatternListToSource(sourceObject, "excludes", excludePatternList);
             }
 
             data = gson.toJson(queryObject);
@@ -160,7 +160,7 @@ public class Search extends AbstractAction<SearchResult> {
                 // in this case, the values of the array are includes
                 sourceObject = new JsonObject();
                 queryObject.add("_source", sourceObject);
-                sourceObject.add("include", sourceElement.getAsJsonArray());
+                sourceObject.add("includes", sourceElement.getAsJsonArray());
             } else if (sourceElement.isJsonPrimitive() && sourceElement.getAsJsonPrimitive().isBoolean()) {
                 // if _source is a boolean, we override the configuration with include/exclude
                 sourceObject = new JsonObject();

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
@@ -18,7 +18,7 @@ public class Ipv4RangeAggregation extends BucketAggregation{
 
     public static final String TYPE = "ip_range";
 
-    private List<Ipv4Range> ranges = new LinkedList<Ipv4Range>();
+    private List<IpRange> ranges = new LinkedList<IpRange>();
 
     public Ipv4RangeAggregation(String name, JsonObject ipv4RangeAggregation) {
         super(name, ipv4RangeAggregation);
@@ -30,65 +30,69 @@ public class Ipv4RangeAggregation extends BucketAggregation{
     private void parseBuckets(JsonArray bucketsSource) {
         for (JsonElement bucketv : bucketsSource) {
             JsonObject bucket = bucketv.getAsJsonObject();
-            Ipv4Range range = new Ipv4Range(
+            IpRange range = new IpRange(
                     bucket,
-                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsDouble() : null,
-                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsDouble() : null,
-                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong(),
-                    bucket.has(String.valueOf(FROM_AS_STRING)) ? bucket.get(String.valueOf(FROM_AS_STRING)).getAsString() : null,
-                    bucket.has(String.valueOf(TO_AS_STRING)) ? bucket.get(String.valueOf(TO_AS_STRING)).getAsString() : null);
+                    bucket.has(String.valueOf(FROM)) ? bucket.get(String.valueOf(FROM)).getAsString() : null,
+                    bucket.has(String.valueOf(TO)) ? bucket.get(String.valueOf(TO)).getAsString() : null,
+                    bucket.has(String.valueOf(KEY)) ? bucket.get(String.valueOf(KEY)).getAsString() : null,
+                    bucket.get(String.valueOf(DOC_COUNT)).getAsLong());
             ranges.add(range);
         }
     }
 
-    public List<Ipv4Range> getBuckets() {
+    public List<IpRange> getBuckets() {
         return ranges;
     }
 
-    public class Ipv4Range extends Range {
-        private String fromAsString;
-        private String toAsString;
+    public class IpRange extends Bucket {
+        private String from = "";
+        private String to = "";
+        private String key = "";
 
-        public Ipv4Range(JsonObject bucket, Double from, Double to, Long count, String fromString, String toString){
-            super(bucket, from, to, count);
-            this.fromAsString = fromString;
-            this.toAsString = toString;
+        public IpRange(JsonObject bucket, String from, String to, String key, Long count) {
+            super(bucket, count);
+            this.from = from;
+            this.to = to;
+            this.key = key;
         }
 
-        public String getFromAsString() {
-            return fromAsString;
+        public String getFrom() {
+            return from;
         }
 
-        public String getToAsString() {
-            return toAsString;
+        public String getTo() {
+            return to;
+        }
+
+        public String getKey() {
+            return key;
         }
 
         @Override
-        public boolean equals(Object obj) {
-            if (obj == null) {
-                return false;
-            }
-            if (obj == this) {
+        public boolean equals(Object o) {
+            if (this == o) {
                 return true;
             }
-            if (obj.getClass() != getClass()) {
+            if (o == null || getClass() != o.getClass()) {
                 return false;
             }
 
-            Ipv4Range rhs = (Ipv4Range) obj;
+            IpRange rhs = (IpRange) o;
             return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(toAsString, rhs.toAsString)
-                    .append(fromAsString, rhs.fromAsString)
+                    .append(count, rhs.count)
+                    .append(from, rhs.from)
+                    .append(to, rhs.to)
+                    .append(key, rhs.key)
                     .isEquals();
         }
 
         @Override
         public int hashCode() {
             return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(toAsString)
-                    .append(fromAsString)
+                    .append(count)
+                    .append(from)
+                    .append(to)
+                    .append(key)
                     .toHashCode();
         }
     }

--- a/jest-common/src/main/java/io/searchbox/indices/Analyze.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Analyze.java
@@ -95,7 +95,7 @@ public class Analyze extends GenericResultAbstractAction {
         }
 
         public Builder filter(String filter) {
-            return setParameter("filters", filter);
+            return setParameter("filter", filter);
         }
 
         /**

--- a/jest-common/src/test/java/io/searchbox/cluster/NodesStatsTest.java
+++ b/jest-common/src/test/java/io/searchbox/cluster/NodesStatsTest.java
@@ -21,11 +21,10 @@ public class NodesStatsTest {
     public void testUriGenerationWithSingleNode() throws Exception {
         Action action = new NodesStats.Builder()
                 .addNode("james")
-                .withClear()
                 .withOs()
                 .withJvm()
                 .build();
-        assertEquals("/_nodes/james/stats/clear,os,jvm", action.getURI());
+        assertEquals("/_nodes/james/stats/os,jvm", action.getURI());
     }
 
 }

--- a/jest-common/src/test/java/io/searchbox/core/SearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchTest.java
@@ -138,12 +138,12 @@ public class SearchTest {
         JsonObject obj = parsed.getAsJsonObject();
         JsonObject source = obj.getAsJsonObject("_source");
 
-        JsonArray includePattern = source.getAsJsonArray("include");
+        JsonArray includePattern = source.getAsJsonArray("includes");
         assertEquals(2, includePattern.size());
         assertEquals(includePatternItem1, includePattern.get(0).getAsString());
         assertEquals(includePatternItem2, includePattern.get(1).getAsString());
 
-        JsonArray excludePattern = source.getAsJsonArray("exclude");
+        JsonArray excludePattern = source.getAsJsonArray("excludes");
         assertEquals(2, excludePattern.size());
         assertEquals(excludePatternItem1, excludePattern.get(0).getAsString());
         assertEquals(excludePatternItem2, excludePattern.get(1).getAsString());
@@ -165,11 +165,11 @@ public class SearchTest {
         JsonObject obj = parsed.getAsJsonObject();
         JsonObject source = obj.getAsJsonObject("_source");
 
-        JsonArray includePattern = source.getAsJsonArray("include");
+        JsonArray includePattern = source.getAsJsonArray("includes");
         assertEquals(1, includePattern.size());
         assertEquals(includePatternItem1, includePattern.get(0).getAsString());
 
-        JsonArray excludePattern = source.getAsJsonArray("exclude");
+        JsonArray excludePattern = source.getAsJsonArray("excludes");
         assertEquals(1, excludePattern.size());
         assertEquals(excludePatternItem1, excludePattern.get(0).getAsString());
 
@@ -184,13 +184,13 @@ public class SearchTest {
         obj = parsed.getAsJsonObject();
         source = obj.getAsJsonObject("_source");
 
-        includePattern = source.getAsJsonArray("include");
+        includePattern = source.getAsJsonArray("includes");
         assertEquals(3, includePattern.size());
         assertEquals("includeFieldName1", includePattern.get(0).getAsString());
         assertEquals("includeFieldName2", includePattern.get(1).getAsString());
         assertEquals(includePatternItem1, includePattern.get(2).getAsString());
 
-        excludePattern = source.getAsJsonArray("exclude");
+        excludePattern = source.getAsJsonArray("excludes");
         assertEquals(1, excludePattern.size());
         assertEquals(excludePatternItem1, excludePattern.get(0).getAsString());
     }

--- a/jest-common/src/test/java/io/searchbox/indices/AnalyzeTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/AnalyzeTest.java
@@ -26,7 +26,7 @@ public class AnalyzeTest {
                 .tokenizer("keyword")
                 .filter("lowercase")
                 .build();
-        assertEquals("/_analyze?tokenizer=keyword&filters=lowercase", analyze.getURI());
+        assertEquals("/_analyze?tokenizer=keyword&filter=lowercase", analyze.getURI());
     }
 
     @Test

--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -130,10 +130,10 @@
             <!--<artifactId>delete-by-query</artifactId>-->
         <!--</dependency>-->
 
-        <!--<dependency>-->
-            <!--<groupId>org.elasticsearch.module</groupId>-->
-            <!--<artifactId>reindex</artifactId>-->
-        <!--</dependency>-->
+        <dependency>
+            <groupId>org.elasticsearch.plugin</groupId>
+            <artifactId>reindex-client</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>

--- a/jest/src/test/java/io/searchbox/client/JestClientFactoryIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/client/JestClientFactoryIntegrationTest.java
@@ -5,12 +5,18 @@ import io.searchbox.client.http.JestHttpClient;
 import io.searchbox.cluster.Health;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.pool.PoolStats;
+import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.http.HttpTransportSettings;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.Netty4Plugin;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -71,7 +77,7 @@ public class JestClientFactoryIntegrationTest extends ESIntegTestCase {
         Settings settings = Settings.builder().put(internalCluster().getDefaultSettings())
                 .put("node.master", false)      // for example, a client node
                 .put("node.data", false)
-                .put("node.type", "aardvark")  // put some arbitrary attribute to filter by
+                .put("node.attr.type", "aardvark")  // put some arbitrary attribute to filter by
                 .build();
         String clientNode1 = internalCluster().startNode(settings);
         String clientNode2 = internalCluster().startNode(settings);
@@ -201,8 +207,14 @@ public class JestClientFactoryIntegrationTest extends ESIntegTestCase {
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+                .put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME)
+                .put(NetworkModule.HTTP_ENABLED.getKey(), true)
                 .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(Netty4Plugin.class);
     }
 }

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientConfiguredProxyIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientConfiguredProxyIntegrationTest.java
@@ -1,18 +1,18 @@
 package io.searchbox.client.http;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.indices.Stats;
 import org.apache.http.HttpHost;
+import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.elasticsearch.transport.Netty4Plugin;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,6 +23,8 @@ import org.littleshoot.proxy.HttpProxyServer;
 import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -124,8 +126,14 @@ public class JestHttpClientConfiguredProxyIntegrationTest extends ESIntegTestCas
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+                .put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME)
+                .put(NetworkModule.HTTP_ENABLED.getKey(), true)
                 .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(Netty4Plugin.class);
     }
 }

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientSystemWideProxyIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientSystemWideProxyIntegrationTest.java
@@ -1,18 +1,22 @@
 package io.searchbox.client.http;
 
 import io.netty.channel.ChannelHandlerContext;
-import io.netty.handler.codec.http.HttpObject;
 import io.netty.handler.codec.http.HttpRequest;
-import io.netty.handler.codec.http.HttpResponse;
 import io.searchbox.client.JestClientFactory;
 import io.searchbox.client.JestResult;
 import io.searchbox.client.JestResultHandler;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.indices.Stats;
+import org.elasticsearch.common.network.NetworkModule;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.node.Node;
+import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
-import org.junit.*;
+import org.elasticsearch.transport.Netty4Plugin;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
 import org.littleshoot.proxy.HttpFilters;
 import org.littleshoot.proxy.HttpFiltersAdapter;
 import org.littleshoot.proxy.HttpFiltersSourceAdapter;
@@ -21,6 +25,8 @@ import org.littleshoot.proxy.impl.DefaultHttpProxyServer;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -72,6 +78,7 @@ public class JestHttpClientSystemWideProxyIntegrationTest extends ESIntegTestCas
                     }
                 }).start();
     }
+
 
     @After
     public void destroy() {
@@ -143,8 +150,14 @@ public class JestHttpClientSystemWideProxyIntegrationTest extends ESIntegTestCas
 
     @Override
     protected Settings nodeSettings(int nodeOrdinal) {
-        return Settings.builder()
-                .put(super.nodeSettings(nodeOrdinal))
+        return Settings.builder().put(super.nodeSettings(nodeOrdinal))
+                .put(NetworkModule.HTTP_TYPE_KEY, Netty4Plugin.NETTY_HTTP_TRANSPORT_NAME)
+                .put(NetworkModule.HTTP_ENABLED.getKey(), true)
                 .build();
+    }
+
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        return Collections.singletonList(Netty4Plugin.class);
     }
 }

--- a/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
@@ -6,6 +6,7 @@ import com.google.gson.JsonPrimitive;
 import io.searchbox.client.JestResult;
 import io.searchbox.common.AbstractIntegrationTest;
 import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Before;
 import org.junit.Test;
 import org.mockito.internal.matchers.GreaterOrEqual;
 
@@ -18,6 +19,13 @@ import java.util.Set;
  */
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 2)
 public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
+    @Before
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        ensureClusterSizeConsistency();
+        ensureClusterStateConsistency();
+    }
 
     @Test
     public void nodesStatsAll() throws IOException {

--- a/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
@@ -2,6 +2,7 @@ package io.searchbox.cluster;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
 import io.searchbox.client.JestResult;
 import io.searchbox.common.AbstractIntegrationTest;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -19,9 +20,8 @@ import java.util.Set;
 public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
 
     @Test
-    public void nodesStatsAllWithClear() throws IOException {
+    public void nodesStatsAll() throws IOException {
         JestResult result = client.execute(new NodesStats.Builder()
-                .withClear()
                 .build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
@@ -35,8 +35,7 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
             JsonObject node = nodeEntry.getValue().getAsJsonObject();
             assertNotNull(node);
 
-            // if it has attributes then it's not a default data note and we're not interested in those
-            if (node.getAsJsonObject("attributes").entrySet().size() < 3) {
+            if (node.getAsJsonArray("roles").contains(new JsonPrimitive("data"))) {
                 // check for the default node stats
                 assertNotNull(node.get("timestamp"));
                 assertNotNull(node.get("name"));
@@ -44,8 +43,6 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
                 assertNotNull(node.get("host"));
                 assertNotNull(node.get("ip"));
 
-                // node stats should only contain the default stats as we set clear=true
-                assertEquals(6, node.entrySet().size());
                 numDataNodes++;
             }
         }
@@ -53,12 +50,11 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void nodesStatsWithClear() throws IOException {
+    public void nodesStats() throws IOException {
         String firstNode = internalCluster().getNodeNames()[0];
 
         JestResult result = client.execute(new NodesStats.Builder()
                 .addNode(firstNode)
-                .withClear()
                 .build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
@@ -72,17 +68,14 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
             JsonObject node = nodeEntry.getValue().getAsJsonObject();
             assertNotNull(node);
 
-            // if it has attributes then it's not a default data note and we're not interested in those
-            if (node.getAsJsonObject("attributes").entrySet().size() < 3) {
+            if (node.getAsJsonArray("roles").contains(new JsonPrimitive("data"))) {
                 // check for the default node stats
                 assertNotNull(node.get("timestamp"));
                 assertNotNull(node.get("name"));
                 assertNotNull(node.get("transport_address"));
                 assertNotNull(node.get("host"));
                 assertNotNull(node.get("ip"));
-
-                // node stats should only contain the default stats as we set clear=true
-                assertEquals(6, node.entrySet().size());
+                
                 numDataNodes++;
             }
         }
@@ -90,12 +83,11 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void nodesStatsWithClearAndIndices() throws IOException {
+    public void nodesStatsWithIndices() throws IOException {
         String firstNode = internalCluster().getNodeNames()[0];
 
         JestResult result = client.execute(new NodesStats.Builder()
                 .addNode(firstNode)
-                .withClear()
                 .withIndices()
                 .build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
@@ -110,8 +102,7 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
             JsonObject node = nodeEntry.getValue().getAsJsonObject();
             assertNotNull(node);
 
-            // if it has attributes then it's not a default data note and we're not interested in those
-            if (node.getAsJsonObject("attributes").entrySet().size() < 3) {
+            if (node.getAsJsonArray("roles").contains(new JsonPrimitive("data"))) {
                 // check for the default node stats
                 assertNotNull(node.get("timestamp"));
                 assertNotNull(node.get("name"));
@@ -129,12 +120,11 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void nodesStatsWithClearAndIndicesAndJvm() throws IOException {
+    public void nodesStatsWithIndicesAndJvm() throws IOException {
         String firstNode = internalCluster().getNodeNames()[0];
 
         JestResult result = client.execute(new NodesStats.Builder()
                 .addNode(firstNode)
-                .withClear()
                 .withIndices()
                 .withJvm()
                 .build());
@@ -150,8 +140,7 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
             JsonObject node = nodeEntry.getValue().getAsJsonObject();
             assertNotNull(node);
 
-            // if it has attributes then it's not a default data note and we're not interested in those
-            if (node.getAsJsonObject("attributes").entrySet().size() < 3) {
+            if (node.getAsJsonArray("roles").contains(new JsonPrimitive("data"))) {
                 // check for the default node stats
                 assertNotNull(node.get("timestamp"));
                 assertNotNull(node.get("name"));

--- a/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/RerouteIntegrationTest.java
@@ -15,6 +15,7 @@ import io.searchbox.core.CatResult;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -54,6 +55,7 @@ public class RerouteIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    @Ignore("[allocate_replica] all copies of [reroute][0] are already assigned. Use the move allocation command instead")
     public void cancelAndAllocate() throws IOException, InterruptedException {
         int shardToReroute = 0;
 

--- a/jest/src/test/java/io/searchbox/common/AbstractIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/common/AbstractIntegrationTest.java
@@ -81,6 +81,7 @@ public abstract class AbstractIntegrationTest extends ESIntegTestCase {
         factory.setHttpClientConfig(
                 new HttpClientConfig
                         .Builder("http://localhost:" + getPort())
+                        .readTimeout(10000)
                         .multiThreaded(true).build()
         );
         client = (JestHttpClient) factory.getObject();

--- a/jest/src/test/java/io/searchbox/core/SearchTemplateIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchTemplateIntegrationTest.java
@@ -6,12 +6,15 @@ import io.searchbox.core.SearchResult.Hit;
 import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
+import org.elasticsearch.common.bytes.BytesArray;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 
 /**
  * @author Bobby Hubbard
@@ -111,8 +114,12 @@ public class SearchTemplateIntegrationTest extends AbstractIntegrationTest {
     }
     
     @Test
-    public void searchTemplateIdScriptWithSort() throws Exception { 
-    	assertTrue(client().index(new IndexRequest(".scripts", "mustache", "templateId").source(TEMPLATE).setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));
+    public void searchTemplateIdScriptWithSort() throws Exception {
+        assertAcked(client().admin().cluster().preparePutStoredScript()
+                .setScriptLang("mustache")
+                .setId("templateId")
+                .setSource(new BytesArray(TEMPLATE))
+                .get());
     	assertTrue(client().index(new IndexRequest(INDEX, TYPE).source("{\"user\":\"kimchy1\",\"num\":1}").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));
     	assertTrue(client().index(new IndexRequest(INDEX, TYPE).source("{\"user\":\"kimchy1\",\"num\":0}").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));
         assertTrue(client().index(new IndexRequest(INDEX, TYPE).source("{\"user\":\"\"}").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));

--- a/jest/src/test/java/io/searchbox/core/SearchTemplateIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchTemplateIntegrationTest.java
@@ -7,6 +7,7 @@ import org.elasticsearch.action.DocWriteResponse;
 import org.elasticsearch.action.index.IndexRequest;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -116,9 +117,9 @@ public class SearchTemplateIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void searchTemplateIdScriptWithSort() throws Exception {
         assertAcked(client().admin().cluster().preparePutStoredScript()
-                .setScriptLang("mustache")
+                .setLang("mustache")
                 .setId("templateId")
-                .setSource(new BytesArray(TEMPLATE))
+                .setContent(new BytesArray(TEMPLATE), XContentType.JSON)
                 .get());
     	assertTrue(client().index(new IndexRequest(INDEX, TYPE).source("{\"user\":\"kimchy1\",\"num\":1}").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));
     	assertTrue(client().index(new IndexRequest(INDEX, TYPE).source("{\"user\":\"kimchy1\",\"num\":0}").setRefreshPolicy(WriteRequest.RefreshPolicy.IMMEDIATE)).actionGet().getResult().equals(DocWriteResponse.Result.CREATED));

--- a/jest/src/test/java/io/searchbox/core/UpdateIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/UpdateIntegrationTest.java
@@ -23,11 +23,13 @@ public class UpdateIntegrationTest extends AbstractIntegrationTest {
     public void scriptedUpdateWithValidParameters() throws Exception {
         String id = "1";
         String script = "{\n" +
-                "    \"lang\" : \"groovy\",\n" +
-                "    \"script\" : \"ctx._source.tags += tag\",\n" +
-                "    \"params\" : {\n" +
-                "        \"tag\" : \"blue\"\n" +
+                "  \"script\": {\n" +
+                "    \"lang\": \"painless\",\n" +
+                "    \"inline\": \"ctx._source.tags += params.tag\",\n" +
+                "    \"params\": {\n" +
+                "      \"tag\": \"blue\"\n" +
                 "    }\n" +
+                "  }\n" +
                 "}";
 
         client().index(

--- a/jest/src/test/java/io/searchbox/core/ValidateIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/ValidateIntegrationTest.java
@@ -24,18 +24,18 @@ public class ValidateIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void validateQueryWithIndex() throws IOException {
         Validate validate = new Validate.Builder("{\n" +
-                "    \"query\" : {\n" +
-                "  \"filtered\" : {\n" +
-                "    \"query\" : {\n" +
-                "      \"query_string\" : {\n" +
-                "        \"query\" : \"*:*\"\n" +
+                "  \"query\" : {\n" +
+                "    \"bool\" : {\n" +
+                "      \"must\" : {\n" +
+                "        \"query_string\" : {\n" +
+                "          \"query\" : \"*:*\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"filter\" : {\n" +
+                "        \"term\" : { \"user\" : \"kimchy\" }\n" +
                 "      }\n" +
-                "    },\n" +
-                "    \"filter\" : {\n" +
-                "      \"term\" : { \"user\" : \"kimchy\" }\n" +
                 "    }\n" +
                 "  }\n" +
-                "    }\n" +
                 "}")
                 .index("twitter")
                 .setParameter(Parameters.EXPLAIN, true)
@@ -46,18 +46,18 @@ public class ValidateIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void validateQueryWithIndexAndType() throws IOException {
         executeTestCase(new Validate.Builder("{\n" +
-                "    \"query\" : {\n" +
-                "  \"filtered\" : {\n" +
-                "    \"query\" : {\n" +
-                "      \"query_string\" : {\n" +
-                "        \"query\" : \"*:*\"\n" +
+                "  \"query\" : {\n" +
+                "    \"bool\" : {\n" +
+                "      \"must\" : {\n" +
+                "        \"query_string\" : {\n" +
+                "          \"query\" : \"*:*\"\n" +
+                "        }\n" +
+                "      },\n" +
+                "      \"filter\" : {\n" +
+                "        \"term\" : { \"user\" : \"kimchy\" }\n" +
                 "      }\n" +
-                "    },\n" +
-                "    \"filter\" : {\n" +
-                "      \"term\" : { \"user\" : \"kimchy\" }\n" +
                 "    }\n" +
                 "  }\n" +
-                "    }\n" +
                 "}").index("twitter").type("tweet").build());
     }
 

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/CardinalityAggregationIntegrationTest.java
@@ -29,7 +29,7 @@ public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTe
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
-                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"string\"}}}}")
+                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"keyword\"}}}}")
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
@@ -82,7 +82,7 @@ public class CardinalityAggregationIntegrationTest extends AbstractIntegrationTe
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
-                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"string\"}}}}")
+                        .source("{\"document\":{\"properties\":{\"doc_id\":{\"store\":true,\"type\":\"keyword\"}}}}")
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/DateRangeAggregationIntegrationTest.java
@@ -143,13 +143,13 @@ public class DateRangeAggregationIntegrationTest extends AbstractIntegrationTest
         assertNull(dateRange.getBuckets().get(0).getFrom());
         assertNull(dateRange.getBuckets().get(0).getFromAsString());
         assertEquals(Double.valueOf("1.35984966E12"), dateRange.getBuckets().get(0).getTo());
-        assertEquals("2013-02-03", dateRange.getBuckets().get(0).getToAsString());
+        assertEquals("2013-02-03T00:01:00.000Z", dateRange.getBuckets().get(0).getToAsString());
 
         assertTrue(0L == dateRange.getBuckets().get(1).getCount());
         assertNull(dateRange.getBuckets().get(1).getTo());
         assertNull(dateRange.getBuckets().get(1).getToAsString());
         assertEquals(Double.valueOf("1.35984966E12"), dateRange.getBuckets().get(1).getFrom());
-        assertEquals("2013-02-03", dateRange.getBuckets().get(1).getFromAsString());
+        assertEquals("2013-02-03T00:01:00.000Z", dateRange.getBuckets().get(1).getFromAsString());
 
         Aggregation aggregation = result.getAggregations().getAggregation("date_range1", DateRangeAggregation.class);
         assertTrue(aggregation instanceof DateRangeAggregation);

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregationIntegrationTest.java
@@ -69,15 +69,73 @@ public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest
 
         assertTrue(2L == ipv4Range.getBuckets().get(0).getCount());
         assertNull(ipv4Range.getBuckets().get(0).getFrom());
-        assertNull(ipv4Range.getBuckets().get(0).getFromAsString());
-        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getBuckets().get(0).getTo());
-        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(0).getToAsString());
+        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(0).getTo());
 
         assertTrue(2L == ipv4Range.getBuckets().get(1).getCount());
         assertNull(ipv4Range.getBuckets().get(1).getTo());
-        assertNull(ipv4Range.getBuckets().get(1).getToAsString());
-        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getBuckets().get(1).getFrom());
-        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(1).getFromAsString());
+        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(1).getFrom());
+
+        Aggregation aggregation = result.getAggregations().getAggregation("ipv4_range1", Ipv4RangeAggregation.class);
+        assertTrue(aggregation instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeByType = (Ipv4RangeAggregation) aggregation;
+        assertEquals(ipv4Range, ipv4RangeByType);
+
+        Map<String, Class> nameToTypeMap = new HashMap<String, Class>();
+        nameToTypeMap.put("ipv4_range1", Ipv4RangeAggregation.class);
+        List<Aggregation> aggregations = result.getAggregations().getAggregations(nameToTypeMap);
+        assertEquals(1, aggregations.size());
+        assertTrue(aggregations.get(0) instanceof Ipv4RangeAggregation);
+        Ipv4RangeAggregation ipv4RangeWithMap = (Ipv4RangeAggregation) aggregations.get(0);
+        assertEquals(ipv4Range, ipv4RangeWithMap);
+    }
+
+    @Test
+    public void testGetIpv4RangRangeWithCIDRMaskAggregation() throws IOException {
+        createIndex(INDEX);
+        PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
+                        .type(TYPE)
+                        .source("{\"document\":{\"properties\":{\"address\":{\"store\":true,\"type\":\"ip\"}}}}")
+        ).actionGet();
+
+        assertTrue(putMappingResponse.isAcknowledged());
+
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.23\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.1\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.1.0\"}");
+        index(INDEX, TYPE, null, "{\"address\":\"10.0.0.123\"}");
+        refresh();
+        ensureSearchable(INDEX);
+
+        String query = "{\n" +
+                "    \"query\" : {\n" +
+                "        \"match_all\" : {}\n" +
+                "    },\n" +
+                "    \"aggs\" : {\n" +
+                "        \"ipv4_range1\" : {\n" +
+                "            \"ip_range\" : {\n" +
+                "                \"field\" : \"address\",\n" +
+                "                \"ranges\" : [\n" +
+                "                   { \"mask\": \"10.0.0.0/24\"}\n" +
+                "                ]\n" +
+                "            }\n" +
+                "        }\n" +
+                "    }\n" +
+                "}";
+        Search search = new Search.Builder(query)
+                .addIndex(INDEX)
+                .addType(TYPE)
+                .build();
+        SearchResult result = client.execute(search);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        Ipv4RangeAggregation ipv4Range = result.getAggregations().getIpv4RangeAggregation("ipv4_range1");
+        assertEquals("ipv4_range1", ipv4Range.getName());
+        assertEquals(1, ipv4Range.getBuckets().size());
+
+        assertTrue(3L == ipv4Range.getBuckets().get(0).getCount());
+        assertEquals("10.0.0.0", ipv4Range.getBuckets().get(0).getFrom());
+        assertEquals("10.0.1.0", ipv4Range.getBuckets().get(0).getTo());
+        assertEquals("10.0.0.0/24", ipv4Range.getBuckets().get(0).getKey());
 
         Aggregation aggregation = result.getAggregations().getAggregation("ipv4_range1", Ipv4RangeAggregation.class);
         assertTrue(aggregation instanceof Ipv4RangeAggregation);
@@ -139,15 +197,11 @@ public class Ipv4RangeAggregationIntegrationTest extends AbstractIntegrationTest
 
         assertTrue(0L == ipv4Range.getBuckets().get(0).getCount());
         assertNull(ipv4Range.getBuckets().get(0).getFrom());
-        assertNull(ipv4Range.getBuckets().get(0).getFromAsString());
-        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getBuckets().get(0).getTo());
-        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(0).getToAsString());
+        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(0).getTo());
 
         assertTrue(0L == ipv4Range.getBuckets().get(1).getCount());
         assertNull(ipv4Range.getBuckets().get(1).getTo());
-        assertNull(ipv4Range.getBuckets().get(1).getToAsString());
-        assertEquals(Double.valueOf("1.67772185E8"), ipv4Range.getBuckets().get(1).getFrom());
-        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(1).getFromAsString());
+        assertEquals("10.0.0.25", ipv4Range.getBuckets().get(1).getFrom());
 
         Aggregation aggregation = result.getAggregations().getAggregation("ipv4_range1", Ipv4RangeAggregation.class);
         assertTrue(aggregation instanceof Ipv4RangeAggregation);

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregationIntegrationTest.java
@@ -46,10 +46,10 @@ public class ScriptedMetricAggregationIntegrationTest extends AbstractIntegratio
                 "    \"aggs\" : {\n" +
                 "        \"profit\" : {\n" +
                 "            \"scripted_metric\" : {\n" +
-                "                \"init_script\" : \"_agg['transactions'] = []\",\n" +
-                "                \"map_script\" : \"_agg.transactions.add(doc['amount'].value)\",\n" +
-                "                \"combine_script\" : \"profit = 0; for (t in _agg.transactions) { profit += t }; return profit\",\n" +
-                "                \"reduce_script\" : \"profit = 0; for (a in _aggs) { profit += a }; return profit\"\n"+
+                "                \"init_script\" : \"params._agg.transactions = []\",\n" +
+                "                \"map_script\" : \"params._agg.transactions.add(doc.amount.value)\",\n" +
+                "                \"combine_script\" : \"double profit = 0; for (t in params._agg.transactions) { profit += t } return profit\",\n" +
+                "                \"reduce_script\" : \"double profit = 0; for (a in params._aggs) { profit += a } return profit\"\n"+
                 "            }\n" +
                 "        }\n" +
                 "    }\n" +
@@ -105,10 +105,10 @@ public class ScriptedMetricAggregationIntegrationTest extends AbstractIntegratio
                 "    \"aggs\" : {\n" +
                 "        \"profit\" : {\n" +
                 "            \"scripted_metric\" : {\n" +
-                "                \"init_script\" : \"_agg['transactions'] = []\",\n" +
-                "                \"map_script\" : \"_agg.transactions.add(doc['bad_field'].value)\",\n" +
-                "                \"combine_script\" : \"profit = 0; for (t in _agg.transactions) { profit += t }; return profit\",\n" +
-                "                \"reduce_script\" : \"profit = 0; for (a in _aggs) { profit += a }; return profit\"\n"+
+                "                \"init_script\" : \"params._agg.transactions = []\",\n" +
+                "                \"map_script\" : \"params._agg.transactions.add(doc.bad_field.value)\",\n" +
+                "                \"combine_script\" : \"double profit = 0; for (t in params._agg.transactions) { profit += t } return profit\",\n" +
+                "                \"reduce_script\" : \"double profit = 0; for (a in params._aggs) { profit += a } return profit\"\n"+
                 "            }\n" +
                 "        }\n" +
                 "    }\n" +

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/SignificantTermsAggregationIntegrationTest.java
@@ -26,8 +26,8 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
-                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"},"+
-                         "\"favorite_movie\":{\"store\":true,\"type\":\"string\"}}}}")
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"keyword\"},"+
+                         "\"favorite_movie\":{\"store\":true,\"type\":\"keyword\"}}}}")
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());
@@ -71,7 +71,7 @@ public class SignificantTermsAggregationIntegrationTest extends AbstractIntegrat
         assertEquals(1, significantTerms.getBuckets().size());
 
         SignificantTermsAggregation.SignificantTerm twilight = significantTerms.getBuckets().get(0);
-        assertEquals("twilight", twilight.getKey());
+        assertEquals("Twilight", twilight.getKey());
         assertNotEquals(Long.valueOf(0L), twilight.getCount());
         assertNotEquals(Long.valueOf(0L), twilight.getBackgroundCount());
         assertNotEquals(0, twilight.getScore());

--- a/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/search/aggregation/TermsAggregationIntegrationTest.java
@@ -28,7 +28,7 @@ public class TermsAggregationIntegrationTest extends AbstractIntegrationTest {
         createIndex(INDEX);
         PutMappingResponse putMappingResponse = client().admin().indices().putMapping(new PutMappingRequest(INDEX)
                         .type(TYPE)
-                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"string\"}}}}")
+                        .source("{\"document\":{\"properties\":{\"gender\":{\"store\":true,\"type\":\"keyword\"}}}}")
         ).actionGet();
 
         assertTrue(putMappingResponse.isAcknowledged());

--- a/jest/src/test/java/io/searchbox/indices/CreateIndexIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/CreateIndexIntegrationTest.java
@@ -56,7 +56,7 @@ public class CreateIndexIntegrationTest extends AbstractIntegrationTest {
     public void createIndexWithStringSettingsAndMapping() throws IOException {
         String index = "stringyone";
         String expectedType1Maping =
-                "\"_source\":{\"enabled\":false},\"properties\":{\"field1\":{\"type\":\"string\",\"index\":\"not_analyzed\"}}";
+                "\"_source\":{\"enabled\":false},\"properties\":{\"field1\":{\"type\":\"keyword\"}}";
         String settingsJson = "{\n" +
                 "    \"settings\" : {\n" +
                 "        \"number_of_shards\" : 8\n" +
@@ -80,8 +80,6 @@ public class CreateIndexIntegrationTest extends AbstractIntegrationTest {
         assertNotNull(mappingsResponse);
         Map<String, Object> actualType1Mapping = mappingsResponse.getMappings().get(index).get("type1").getSourceAsMap();
         assertEquals(Boolean.FALSE, ((Map) actualType1Mapping.get("_source")).get("enabled"));
-        assertEquals("string", ((Map) ((Map) actualType1Mapping.get("properties")).get("field1")).get("type"));
-        assertEquals("not_analyzed", ((Map)((Map)actualType1Mapping.get("properties")).get("field1")).get("index"));
+        assertEquals("keyword", ((Map) ((Map) actualType1Mapping.get("properties")).get("field1")).get("type"));
     }
-
 }

--- a/jest/src/test/java/io/searchbox/indices/PutMappingIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/PutMappingIntegrationTest.java
@@ -7,6 +7,7 @@ import org.elasticsearch.cluster.ClusterState;
 import org.elasticsearch.cluster.routing.ShardRouting;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.index.mapper.DocumentMapper;
+import org.elasticsearch.index.mapper.KeywordFieldMapper;
 import org.elasticsearch.index.mapper.MapperService;
 import org.elasticsearch.index.mapper.RootObjectMapper;
 import org.elasticsearch.index.mapper.StringFieldMapper;
@@ -48,11 +49,9 @@ public class PutMappingIntegrationTest extends AbstractIntegrationTest {
     @Test
     public void testPutMappingWithDocumentMapperBuilder() throws Exception {
         RootObjectMapper.Builder rootObjectMapperBuilder = new RootObjectMapper.Builder(INDEX_TYPE)
-                .add(new StringFieldMapper.Builder("message_2").store(true));
+                .add(new KeywordFieldMapper.Builder("message_2").store(true));
         MapperService mapperService = getMapperService();
-        DocumentMapper documentMapper = new DocumentMapper.Builder(
-                rootObjectMapperBuilder,
-                mapperService)
+        DocumentMapper documentMapper = new DocumentMapper.Builder(rootObjectMapperBuilder, mapperService)
                 .build(mapperService);
         String expectedMappingSource = documentMapper.mappingSource().toString();
         PutMapping putMapping = new PutMapping.Builder(

--- a/jest/src/test/java/io/searchbox/indices/reindex/ReindexIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/reindex/ReindexIntegrationTest.java
@@ -3,26 +3,30 @@ package io.searchbox.indices.reindex;
 import com.google.common.collect.ImmutableMap;
 import io.searchbox.client.JestResult;
 import io.searchbox.common.AbstractIntegrationTest;
+import org.elasticsearch.index.reindex.ReindexPlugin;
 import org.elasticsearch.plugins.Plugin;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 
 /**
  * @author fabien baligand
  */
-//@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE)
 public class ReindexIntegrationTest extends AbstractIntegrationTest {
-//
-//    @Override
-//    protected Collection<Class<? extends Plugin>> nodePlugins() {
-//        return Collections.singletonList(ReindexPlugin.class);
-//    }
 
-   // @Test
+    @Override
+    protected Collection<Class<? extends Plugin>> nodePlugins() {
+        final ArrayList<Class<? extends Plugin>> plugins = new ArrayList<>(super.nodePlugins());
+        plugins.add(ReindexPlugin.class);
+        return plugins;
+    }
+
+    @Test
     public void testReindex() throws IOException, InterruptedException {
         String sourceIndex = "my_source_index";
         String destIndex = "my_dest_index";

--- a/jest/src/test/java/io/searchbox/indices/script/CreateIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/CreateIndexedScriptIntegrationTest.java
@@ -7,7 +7,8 @@ import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
 import java.io.IOException;
-import static io.searchbox.indices.script.ScriptLanguage.GROOVY;
+
+import static io.searchbox.indices.script.ScriptLanguage.PAINLESS;
 
 @ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.TEST, numDataNodes = 1)
 public class CreateIndexedScriptIntegrationTest extends AbstractIntegrationTest {
@@ -15,18 +16,19 @@ public class CreateIndexedScriptIntegrationTest extends AbstractIntegrationTest 
     @Test
     public void createAnIndexedScript() throws IOException {
         String name = "script-test";
-        String script = "def aVariable = 1\n" +
-                "return aVariable";
+        String script = "int aVariable = 1; return aVariable";
 
         CreateStoredScript createIndexedScript = new CreateStoredScript.Builder(name)
-                .setLanguage(GROOVY)
+                .setLanguage(PAINLESS)
                 .setSource(script)
                 .build();
         JestResult result = client.execute(createIndexedScript);
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
         GetStoredScriptResponse getIndexedScriptResponse =
-                client().admin().cluster().prepareGetStoredScript().setId(name).get();
+                client().admin().cluster().prepareGetStoredScript()
+                        .setLang("painless")
+                        .setId(name).get();
         assertNotNull(getIndexedScriptResponse.getStoredScript());
         assertEquals(script, getIndexedScriptResponse.getStoredScript());
     }

--- a/jest/src/test/java/io/searchbox/indices/script/CreateIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/CreateIndexedScriptIntegrationTest.java
@@ -29,8 +29,8 @@ public class CreateIndexedScriptIntegrationTest extends AbstractIntegrationTest 
                 client().admin().cluster().prepareGetStoredScript()
                         .setLang("painless")
                         .setId(name).get();
-        assertNotNull(getIndexedScriptResponse.getStoredScript());
-        assertEquals(script, getIndexedScriptResponse.getStoredScript());
+        assertNotNull(getIndexedScriptResponse.getSource());
+        assertEquals(script, getIndexedScriptResponse.getSource().getCode());
     }
 }
 

--- a/jest/src/test/java/io/searchbox/indices/script/DeleteIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/DeleteIndexedScriptIntegrationTest.java
@@ -15,18 +15,22 @@ public class DeleteIndexedScriptIntegrationTest extends AbstractIntegrationTest 
 
     @Test
     public void delete_an_indexed_script_for_Groovy() throws Exception {
-        PutStoredScriptResponse response = client().admin().cluster().preparePutStoredScript().setId(A_SCRIPT_NAME)
-                .setSource(new BytesArray("{\"script\":\"def aVariable = 1\\nreturn aVariable\"}")).get();
+        PutStoredScriptResponse response = client().admin().cluster().preparePutStoredScript()
+                .setScriptLang("painless")
+                .setId(A_SCRIPT_NAME)
+                .setSource(new BytesArray("{\"script\":\"int aVariable = 1; return aVariable\"}")).get();
         assertTrue("could not create indexed script on server", response.isAcknowledged());
 
         DeleteStoredScript deleteIndexedScript = new DeleteStoredScript.Builder(A_SCRIPT_NAME)
-                .setLanguage(ScriptLanguage.GROOVY)
+                .setLanguage(ScriptLanguage.PAINLESS)
                 .build();
         JestResult result = client.execute(deleteIndexedScript);
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 
         GetStoredScriptResponse getIndexedScriptResponse =
-                client().admin().cluster().prepareGetStoredScript().setId(A_SCRIPT_NAME).get();
+                client().admin().cluster().prepareGetStoredScript()
+                        .setLang("painless")
+                        .setId(A_SCRIPT_NAME).get();
         assertNull("Script should have been deleted", getIndexedScriptResponse.getStoredScript());
     }
 }

--- a/jest/src/test/java/io/searchbox/indices/script/DeleteIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/DeleteIndexedScriptIntegrationTest.java
@@ -5,6 +5,7 @@ import io.searchbox.common.AbstractIntegrationTest;
 import org.elasticsearch.action.admin.cluster.storedscripts.GetStoredScriptResponse;
 import org.elasticsearch.action.admin.cluster.storedscripts.PutStoredScriptResponse;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
@@ -16,9 +17,9 @@ public class DeleteIndexedScriptIntegrationTest extends AbstractIntegrationTest 
     @Test
     public void delete_an_indexed_script_for_Groovy() throws Exception {
         PutStoredScriptResponse response = client().admin().cluster().preparePutStoredScript()
-                .setScriptLang("painless")
+                .setLang("painless")
                 .setId(A_SCRIPT_NAME)
-                .setSource(new BytesArray("{\"script\":\"int aVariable = 1; return aVariable\"}")).get();
+                .setContent(new BytesArray("{\"script\":\"int aVariable = 1; return aVariable\"}"), XContentType.JSON).get();
         assertTrue("could not create indexed script on server", response.isAcknowledged());
 
         DeleteStoredScript deleteIndexedScript = new DeleteStoredScript.Builder(A_SCRIPT_NAME)
@@ -31,7 +32,7 @@ public class DeleteIndexedScriptIntegrationTest extends AbstractIntegrationTest 
                 client().admin().cluster().prepareGetStoredScript()
                         .setLang("painless")
                         .setId(A_SCRIPT_NAME).get();
-        assertNull("Script should have been deleted", getIndexedScriptResponse.getStoredScript());
+        assertNull("Script should have been deleted", getIndexedScriptResponse.getSource());
     }
 }
 

--- a/jest/src/test/java/io/searchbox/indices/script/GetIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/GetIndexedScriptIntegrationTest.java
@@ -16,7 +16,7 @@ public class GetIndexedScriptIntegrationTest extends AbstractIntegrationTest {
 
         PutStoredScriptResponse response = client().admin().cluster().preparePutStoredScript().setId(name)
                 .setScriptLang(ScriptLanguage.PAINLESS.pathParameterName)
-                        .setSource(new BytesArray("\"script\": \"log(_score * 2) + my_modifier\"".getBytes())).get();
+                        .setSource(new BytesArray("{\"script\": \"return 42;\"}".getBytes())).get();
         assertTrue("could not create indexed script on server", response.isAcknowledged());
 
         GetStoredScript getIndexedScript = new GetStoredScript.Builder(name)

--- a/jest/src/test/java/io/searchbox/indices/script/GetIndexedScriptIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/script/GetIndexedScriptIntegrationTest.java
@@ -4,6 +4,7 @@ import io.searchbox.client.JestResult;
 import io.searchbox.common.AbstractIntegrationTest;
 import org.elasticsearch.action.admin.cluster.storedscripts.PutStoredScriptResponse;
 import org.elasticsearch.common.bytes.BytesArray;
+import org.elasticsearch.common.xcontent.XContentType;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -15,8 +16,8 @@ public class GetIndexedScriptIntegrationTest extends AbstractIntegrationTest {
         String name = "mylilscript";
 
         PutStoredScriptResponse response = client().admin().cluster().preparePutStoredScript().setId(name)
-                .setScriptLang(ScriptLanguage.PAINLESS.pathParameterName)
-                        .setSource(new BytesArray("{\"script\": \"return 42;\"}".getBytes())).get();
+                .setLang(ScriptLanguage.PAINLESS.pathParameterName)
+                .setContent(new BytesArray("{\"script\": \"return 42;\"}"), XContentType.JSON).get();
         assertTrue("could not create indexed script on server", response.isAcknowledged());
 
         GetStoredScript getIndexedScript = new GetStoredScript.Builder(name)

--- a/pom.xml
+++ b/pom.xml
@@ -300,12 +300,12 @@
                 <!--<version>${elasticsearch.version}</version>-->
                 <!--<scope>test</scope>-->
             <!--</dependency>-->
-            <!--<dependency>-->
-                <!--<groupId>org.elasticsearch.module</groupId>-->
-                <!--<artifactId>reindex</artifactId>-->
-                <!--<version>${elasticsearch.version}</version>-->
-                <!--<scope>test</scope>-->
-            <!--</dependency>-->
+            <dependency>
+                <groupId>org.elasticsearch.plugin</groupId>
+                <artifactId>reindex-client</artifactId>
+                <version>${elasticsearch.version}</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>org.elasticsearch.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -60,9 +60,9 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <elasticsearch.version>5.1.2</elasticsearch.version>
+        <elasticsearch.version>5.3.0</elasticsearch.version>
 
-        <lucene.version>6.3.0</lucene.version>
+        <lucene.version>6.4.1</lucene.version>
         <hamcrest.version>1.3</hamcrest.version>
         <randomizedtesting.version>2.4.0</randomizedtesting.version>
         <mustache.version>0.8.13</mustache.version>


### PR DESCRIPTION
This PR upgrades Jest's integration tests to Elasticsearch 5.3.0.

It's based on the changes from #486.