### PR TITLE
Make adding metadata fields in JestResult optional

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -170,9 +170,13 @@ public class JestResult {
     }
 
     public <T> T getSourceAsObject(Class<T> clazz) {
+        return getSourceAsObject(clazz, true);
+    }
+
+    public <T> T getSourceAsObject(Class<T> clazz, boolean addEsMetadataFields) {
         T sourceAsObject = null;
 
-        List<T> sources = getSourceAsObjectList(clazz);
+        List<T> sources = getSourceAsObjectList(clazz, addEsMetadataFields);
         if (sources.size() > 0) {
             sourceAsObject = sources.get(0);
         }
@@ -181,10 +185,14 @@ public class JestResult {
     }
 
     public <T> List<T> getSourceAsObjectList(Class<T> type) {
+        return getSourceAsObjectList(type, true);
+    }
+
+    public <T> List<T> getSourceAsObjectList(Class<T> type, boolean addEsMetadataFields) {
         List<T> objectList = new ArrayList<T>();
 
         if (isSucceeded) {
-            for (JsonElement source : extractSource()) {
+            for (JsonElement source : extractSource(addEsMetadataFields)) {
                 T obj = createSourceObject(source, type);
                 if (obj != null) {
                     objectList.add(obj);


### PR DESCRIPTION
`JestResult#getSourceAsObjectList()` and `JestResult#getSourceAsObject()` used to
add the metadata fields "es_metadata_id" and "es_metadata_version" unconditionally,
which might be the desired for all use cases.

This change set adds a boolean parameter to these methods which controls whether
the metadata fields should be added to the result.