### PR TITLE
issue-489: Update SearchScroll for large scroll_ids

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
@@ -1,6 +1,7 @@
 package io.searchbox.core;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.JsonObject;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.params.Parameters;
@@ -15,13 +16,19 @@ public class SearchScroll extends GenericResultAbstractAction {
     @VisibleForTesting
     static final int MAX_SCROLL_ID_LENGTH = 1900;
     private final String restMethodName;
+    public static final String SCROLL_ID = "scroll_id";
+    public static final String COMMA = ",";
+
 
     protected SearchScroll(Builder builder) {
         super(builder);
 
         if(builder.getScrollId().length() > MAX_SCROLL_ID_LENGTH) {
             this.restMethodName = "POST";
-            this.payload = builder.getScrollId();
+            // represent scroll_id in json for request body
+            JsonObject scrollObject = new JsonObject();
+            scrollObject.addProperty(SCROLL_ID, builder.getScrollId());
+            this.payload = scrollObject.toString();
         } else {
             this.restMethodName = "GET";
         }

--- a/jest-common/src/test/java/io/searchbox/core/SearchScrollTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchScrollTest.java
@@ -1,6 +1,7 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import io.searchbox.action.Action;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
@@ -24,11 +25,15 @@ public class SearchScrollTest {
     @Test
     public void methodIsPostIfScrollIdIsLong() {
         String scrollId = StringUtils.leftPad("scrollId", 2000, 'x');
+
+        JsonObject expectedResults = new JsonObject();
+        expectedResults.addProperty("scroll_id", scrollId);
+
         Action searchScroll = new SearchScroll.Builder(scrollId, "1m").build();
         String uri = searchScroll.getURI();
 
         assertEquals("POST", searchScroll.getRestMethodName());
-        assertEquals(scrollId, searchScroll.getData(new Gson()));
+        assertEquals(expectedResults.toString(), searchScroll.getData(new Gson()));
         assertTrue(uri.length() < 2000);
         assertFalse(uri.contains(scrollId));
     }


### PR DESCRIPTION
Here's the fix that would be helpful for scrolling when used with Elasticsearch 2.x and 5.x.  By adding the "scroll_id" key to the request body it becomes compliant with both Elasticsearch versions.

The current implementation places the scroll id in the request body without the scroll_id key, which was only allowed in Elasticsearch 2.x.
```
{
"<very long scroll id>"
}
```

This change allows the use with both Elasticsearch 2.x and 5.x

```
{
"scroll_id": "<very long scroll id>"
}
```
