### PR TITLE
Add support for various parameters to Health

### DIFF
--- a/jest-common/src/main/java/io/searchbox/cluster/Health.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/Health.java
@@ -1,13 +1,45 @@
 package io.searchbox.cluster;
 
-import io.searchbox.action.AbstractAction;
+import com.google.common.base.Preconditions;
+import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 
 /**
  * @author Dogukan Sonmez
  * @author Neil Gentleman
  */
 public class Health extends GenericResultAbstractAction {
+    enum Status {
+        RED("red"), YELLOW("yellow"), GREEN("green");
+
+        private final String key;
+
+        Status(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
+
+    enum Level {
+        CLUSTER("cluster"), INDICES("indices"), SHARDS("shards");
+
+        private final String key;
+
+        Level(String key) {
+            this.key = key;
+        }
+
+        public String getKey() {
+            return key;
+        }
+    }
 
     protected Health(Builder builder) {
         super(builder);
@@ -16,7 +48,19 @@ public class Health extends GenericResultAbstractAction {
 
     @Override
     protected String buildURI() {
-        return super.buildURI() + "/_cluster/health/";
+        StringBuilder sb = new StringBuilder("/_cluster/health/");
+
+        try {
+            if (StringUtils.isNotBlank(indexName)) {
+                sb.append(URLEncoder.encode(indexName, CHARSET));
+            }
+        } catch (UnsupportedEncodingException e) {
+            // unless CHARSET is overridden with a wrong value in a subclass,
+            // this exception won't be thrown.
+            log.error("Error occurred while adding index to uri", e);
+        }
+
+        return sb.toString();
     }
 
     @Override
@@ -24,7 +68,43 @@ public class Health extends GenericResultAbstractAction {
         return "GET";
     }
 
-    public static class Builder extends AbstractAction.Builder<Health, Builder> {
+    public static class Builder extends AbstractMultiIndexActionBuilder<Health, Builder> {
+        public Builder waitForNoRelocatingShards() {
+            return waitForNoRelocatingShards(true);
+        }
+
+        public Builder waitForNoRelocatingShards(boolean wait) {
+            return setParameter("wait_for_no_relocating_shards", wait);
+        }
+
+        public Builder waitForStatus(Status status) {
+            return waitForStatus(status.getKey());
+        }
+
+        private Builder waitForStatus(String status) {
+            return setParameter("wait_for_status", status);
+        }
+
+        public Builder level(Level level) {
+            return level(level.getKey());
+        }
+
+        private Builder level(String level) {
+            return setParameter("level", level);
+        }
+
+        public Builder local(boolean local) {
+            return setParameter("local", local);
+        }
+
+        public Builder local() {
+            return local(true);
+        }
+
+        public Builder timeout(int seconds) {
+            Preconditions.checkArgument(seconds >= 0, "seconds must not be negative");
+            return setParameter("timeout", seconds + "s");
+        }
 
         @Override
         public Health build() {

--- a/jest/src/test/java/io/searchbox/cluster/HealthIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/HealthIntegrationTest.java
@@ -5,6 +5,7 @@ import io.searchbox.common.AbstractIntegrationTest;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Test;
 
+import static org.elasticsearch.test.hamcrest.ElasticsearchAssertions.assertAcked;
 import static org.hamcrest.core.AnyOf.anyOf;
 import static org.hamcrest.core.IsEqual.equalTo;
 
@@ -24,4 +25,77 @@ public class HealthIntegrationTest extends AbstractIntegrationTest {
         );
     }
 
+    @Test
+    public void healthWithIndex() throws Exception {
+        assertAcked(prepareCreate("test1").get());
+        final Health request = new Health.Builder()
+                .addIndex("test1")
+                .build();
+        JestResult result = client.execute(request);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertThat(
+                result.getJsonObject().get("status").getAsString(),
+                anyOf(equalTo("green"), equalTo("yellow"), equalTo("red"))
+        );
+    }
+
+    @Test
+    public void healthWaitForStatus() throws Exception {
+        final Health request = new Health.Builder()
+                .waitForStatus(Health.Status.GREEN)
+                .build();
+        JestResult result = client.execute(request);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertEquals("green", result.getJsonObject().get("status").getAsString());
+    }
+
+    @Test
+    public void healthWithTimeout() throws Exception {
+        final Health request = new Health.Builder()
+                .addIndex("test1")
+                .timeout(1)
+                .build();
+        JestResult result = client.execute(request);
+        assertFalse(result.getErrorMessage(), result.isSucceeded());
+        assertEquals(408, result.getResponseCode());
+    }
+
+    @Test
+    public void healthOnlyLocal() throws Exception {
+        final Health request = new Health.Builder()
+                .local()
+                .build();
+        JestResult result = client.execute(request);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertThat(
+                result.getJsonObject().get("status").getAsString(),
+                anyOf(equalTo("green"), equalTo("yellow"), equalTo("red"))
+        );
+    }
+
+    @Test
+    public void healthWaitForNoRelocatingShards() throws Exception {
+        final Health request = new Health.Builder()
+                .waitForNoRelocatingShards()
+                .build();
+        JestResult result = client.execute(request);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertThat(
+                result.getJsonObject().get("status").getAsString(),
+                anyOf(equalTo("green"), equalTo("yellow"), equalTo("red"))
+        );
+    }
+
+    @Test
+    public void healthLevelShards() throws Exception {
+        final Health request = new Health.Builder()
+                .level(Health.Level.SHARDS)
+                .build();
+        JestResult result = client.execute(request);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        assertThat(
+                result.getJsonObject().get("status").getAsString(),
+                anyOf(equalTo("green"), equalTo("yellow"), equalTo("red"))
+        );
+    }
 }


### PR DESCRIPTION
This change set adds support for the following parameters to the `Health.Builder` class:

* `wait_for_status`
* `wait_for_no_relocating_shards`
* `level`
* `timeout`

Additionally it adds support for querying specific indices.

See https://www.elastic.co/guide/en/elasticsearch/reference/5.3/cluster-health.html for details.