### PR TITLE
Fix Travis CI builds

### DIFF
--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>framework</artifactId>
         </dependency>
         <dependency>
+            <groupId>net.java.dev.jna</groupId>
+            <artifactId>jna</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest-all</artifactId>
         </dependency>

--- a/jest/src/test/java/io/searchbox/cluster/StatsIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/StatsIntegrationTest.java
@@ -28,7 +28,7 @@ public class StatsIntegrationTest extends AbstractIntegrationTest {
 
     @Test
     public void clusterStatsWithSpecificNodes() throws IOException {
-        final String localNodeName = clusterService().localNode().name();
+        final String localNodeName = clusterService().localNode().getName();
         JestResult result = client.execute(new Stats.Builder().addNode(localNodeName).build());
         assertTrue(result.getErrorMessage(), result.isSucceeded());
 

--- a/pom.xml
+++ b/pom.xml
@@ -494,5 +494,43 @@
                 </plugins>
             </build>
         </profile>
+        <profile>
+            <id>travis</id>
+            <activation>
+                <property>
+                    <name>env.TRAVIS</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <properties>
+                <tests.heap.size>1g</tests.heap.size>
+            </properties>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>surefire-it</id>
+                                <phase>integration-test</phase>
+                                <goals>
+                                    <goal>test</goal>
+                                </goals>
+                                <configuration>
+                                    <excludes>
+                                        <exclude>none</exclude>
+                                    </excludes>
+                                    <argLine>-XX:+PrintGCDetails -Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Djava.net.preferIPv4Stack=true -Dtests.security.manager=false</argLine>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <argLine>-XX:+PrintGCDetails -Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Dtests.security.manager=false</argLine>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
         <elasticsearch.version>5.3.0</elasticsearch.version>
 
         <lucene.version>6.4.1</lucene.version>
+        <jna.version>4.2.2</jna.version>
         <hamcrest.version>1.3</hamcrest.version>
         <randomizedtesting.version>2.4.0</randomizedtesting.version>
         <mustache.version>0.8.13</mustache.version>
@@ -429,7 +430,7 @@
             <dependency>
                 <groupId>net.java.dev.jna</groupId>
                 <artifactId>jna</artifactId>
-                <version>4.2.2</version>
+                <version>${jna.version}</version>
                 <scope>test</scope>
             </dependency>
 


### PR DESCRIPTION
This change set adds JNA to the test builds and defines a build profile for Travis CI which restricts the heap memory size of the JVM during tests.

Otherwise, the JVM tries to allocate more memory than the Docker container on Travis CI allows.

Related reading material:
* https://developers.redhat.com/blog/2017/03/14/java-inside-docker/
* https://github.com/elastic/elasticsearch/blob/v5.3.0/TESTING.asciidoc#miscellaneous