### PR TITLE
Make Health.Status and Health.Level public

### DIFF
--- a/jest-common/src/main/java/io/searchbox/cluster/Health.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/Health.java
@@ -13,7 +13,7 @@ import java.net.URLEncoder;
  * @author Neil Gentleman
  */
 public class Health extends GenericResultAbstractAction {
-    enum Status {
+    public enum Status {
         RED("red"), YELLOW("yellow"), GREEN("green");
 
         private final String key;
@@ -27,7 +27,7 @@ public class Health extends GenericResultAbstractAction {
         }
     }
 
-    enum Level {
+    public enum Level {
         CLUSTER("cluster"), INDICES("indices"), SHARDS("shards");
 
         private final String key;


### PR DESCRIPTION
It should be possible to use the enums Health.Status and Health.Level in other
packages. These were accidentally only declared in package-protected scope.

Refs searchbox-io/Jest#495