### PR TITLE
Add support for indices flush parameters

### DIFF
--- a/jest-common/src/main/java/io/searchbox/indices/Flush.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Flush.java
@@ -25,6 +25,21 @@ public class Flush extends GenericResultAbstractAction {
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<Flush, Builder> {
+        public Builder force(boolean force) {
+            return setParameter("force", force);
+        }
+
+        public Builder force() {
+            return force(true);
+        }
+
+        public Builder waitIfOngoing(boolean waitIfOngoing) {
+            return setParameter("wait_if_ongoing", waitIfOngoing);
+        }
+
+        public Builder waitIfOngoing() {
+            return waitIfOngoing(true);
+        }
 
         @Override
         public Flush build() {

--- a/jest-common/src/test/java/io/searchbox/indices/FlushTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/FlushTest.java
@@ -16,6 +16,22 @@ public class FlushTest {
     }
 
     @Test
+    public void testBasicUriGenerationWithForce() {
+        Flush flush = new Flush.Builder().addIndex("twitter").force().build();
+
+        assertEquals("POST", flush.getRestMethodName());
+        assertEquals("twitter/_flush?force=true", flush.getURI());
+    }
+
+    @Test
+    public void testBasicUriGenerationWithWaitIfOngoing() {
+        Flush flush = new Flush.Builder().addIndex("twitter").waitIfOngoing().build();
+
+        assertEquals("POST", flush.getRestMethodName());
+        assertEquals("twitter/_flush?wait_if_ongoing=true", flush.getURI());
+    }
+
+    @Test
     public void equalsReturnsTrueForSameIndices() {
         Flush flush1 = new Flush.Builder().addIndex("twitter").addIndex("myspace").build();
         Flush flush1Duplicate = new Flush.Builder().addIndex("twitter").addIndex("myspace").build();
@@ -30,5 +46,4 @@ public class FlushTest {
 
         assertNotEquals(flush1, flush2);
     }
-
 }

--- a/jest/src/test/java/io/searchbox/indices/FlushIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/FlushIntegrationTest.java
@@ -45,6 +45,36 @@ public class FlushIntegrationTest extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testFlushWithForce() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        Flush flush = new Flush.Builder().force().build();
+        JestResult result = client.execute(flush);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        IndicesStatsResponse statsResponse = client().admin().indices().stats(
+                new IndicesStatsRequest().clear().flush(true).refresh(true)).actionGet();
+        assertNotNull(statsResponse);
+        IndexStats stats1 = statsResponse.getIndex(INDEX_NAME);
+
+        assertEquals("There should be exactly one flush operation per shard performed on this index",
+                stats1.getShards().length, stats1.getTotal().getFlush().getTotal());
+    }
+
+    @Test
+    public void testFlushWithWaitifOngoing() throws InterruptedException, ExecutionException, TimeoutException, IOException {
+        Flush flush = new Flush.Builder().waitIfOngoing().build();
+        JestResult result = client.execute(flush);
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+
+        IndicesStatsResponse statsResponse = client().admin().indices().stats(
+                new IndicesStatsRequest().clear().flush(true).refresh(true)).actionGet();
+        assertNotNull(statsResponse);
+        IndexStats stats1 = statsResponse.getIndex(INDEX_NAME);
+
+        assertEquals("There should be exactly one flush operation per shard performed on this index",
+                stats1.getShards().length, stats1.getTotal().getFlush().getTotal());
+    }
+
+    @Test
     public void testFlushSpecificIndices() throws InterruptedException, ExecutionException, TimeoutException, IOException {
         Flush flush = new Flush.Builder().addIndex(INDEX_NAME_2).addIndex(INDEX_NAME_3).build();
         JestResult result = client.execute(flush);


### PR DESCRIPTION
This change set adds support for the "force" and "wait_if_ongoing" parameters to the indices flush operation.

https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-flush.html