### PR TITLE
Add support for simple "ping" (root resource)

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Ping.java
+++ b/jest-common/src/main/java/io/searchbox/core/Ping.java
@@ -1,0 +1,26 @@
+package io.searchbox.core;
+
+import io.searchbox.action.GenericResultAbstractAction;
+
+public class Ping extends GenericResultAbstractAction {
+    protected Ping(Builder builder) {
+        super(builder);
+        setURI(buildURI());
+    }
+
+    @Override
+    protected String buildURI() {
+        return super.buildURI();
+    }
+
+    @Override
+    public String getRestMethodName() {
+        return "GET";
+    }
+
+    public static class Builder extends GenericResultAbstractAction.Builder<Ping, Builder> {
+        public Ping build() {
+            return new Ping(this);
+        }
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/core/PingTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/PingTest.java
@@ -1,0 +1,17 @@
+package io.searchbox.core;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class PingTest {
+    @Test
+    public void testBasicUriGeneration() {
+        Ping ping = new Ping.Builder().build();
+
+        assertEquals("GET", ping.getRestMethodName());
+        assertNull(ping.getData(null));
+        assertEquals("", ping.getURI());
+    }
+}

--- a/jest/src/test/java/io/searchbox/core/PingIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/PingIntegrationTest.java
@@ -1,0 +1,26 @@
+package io.searchbox.core;
+
+import com.google.gson.JsonObject;
+import io.searchbox.client.JestResult;
+import io.searchbox.common.AbstractIntegrationTest;
+import org.elasticsearch.test.ESIntegTestCase;
+import org.junit.Test;
+
+import java.io.IOException;
+
+@ESIntegTestCase.ClusterScope(scope = ESIntegTestCase.Scope.SUITE, numDataNodes = 1)
+public class PingIntegrationTest extends AbstractIntegrationTest {
+    @Test
+    public void simplePing() throws IOException {
+        Ping ping = new Ping.Builder().build();
+        JestResult result = client.execute(ping);
+
+        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        final JsonObject responseJson = result.getJsonObject();
+        assertNotNull(responseJson.getAsJsonPrimitive("name"));
+        assertNotNull(responseJson.getAsJsonPrimitive("cluster_name"));
+        assertNotNull(responseJson.getAsJsonPrimitive("cluster_uuid"));
+        assertNotNull(responseJson.getAsJsonObject("version"));
+        assertEquals("You Know, for Search", responseJson.get("tagline").getAsString());
+    }
+}


### PR DESCRIPTION
This PR adds support for fetching the Elasticsearch root resource (with node name, cluster name, and version information) as a sort of "ping" request, which always succeeds (unless the Elasticsearch node is unavailable).