### PR TITLE
Support track_scores in Search while performing Sort

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/Search.java
+++ b/jest-common/src/main/java/io/searchbox/core/Search.java
@@ -234,6 +234,11 @@ public class Search extends AbstractAction<SearchResult> {
             return setParameter(Parameters.SEARCH_TYPE, searchType);
         }
 
+        public Builder enableTrackScores() {
+            this.setParameter(Parameters.TRACK_SCORES, true);
+            return this;
+        }
+
         public Builder addSort(Sort sort) {
             sortList.add(sort);
             return this;

--- a/jest-common/src/main/java/io/searchbox/params/Parameters.java
+++ b/jest-common/src/main/java/io/searchbox/params/Parameters.java
@@ -79,6 +79,8 @@ public class Parameters {
 
     public static final String RETRY_ON_CONFLICT = "retry_on_conflict";
 
+    public static final String TRACK_SCORES = "track_scores";
+
     public static final List<String> ACCEPTED_IN_BULK = Arrays.asList(
             ROUTING,
             PERCOLATOR,

--- a/jest-common/src/test/java/io/searchbox/core/SearchTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchTest.java
@@ -9,6 +9,8 @@ import static org.junit.Assert.assertTrue;
 import java.util.Arrays;
 import java.util.List;
 
+import io.searchbox.action.AbstractAction;
+import io.searchbox.params.Parameters;
 import org.json.JSONException;
 import org.junit.Test;
 import org.skyscreamer.jsonassert.JSONAssert;
@@ -231,6 +233,15 @@ public class SearchTest {
         test = test.getAsJsonObject("population");
         assertFalse(test.has("order"));
         assertFalse(test.has("order"));
+        AbstractAction srch = (AbstractAction) search;
+        assertTrue(srch.getParameter(Parameters.TRACK_SCORES).size() == 0);
+        search = new Search.Builder(query)
+                .addSort(Arrays.asList(sortByPopulationAsc, sortByPopulationDesc, sortByPopulation))
+                .enableTrackScores()
+                .build();
+        srch = (AbstractAction) search;
+        assertTrue(srch.getParameter(Parameters.TRACK_SCORES).size() == 1);
+        assertTrue((Boolean)srch.getParameter(Parameters.TRACK_SCORES).iterator().next());
     }
 
     @Test


### PR DESCRIPTION
Search object currently doesn't have a way to enable tracking scores while sorting.
https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html#_track_scores