### PR TITLE
Remove Apache Commons Lang3 dependency

### DIFF
--- a/jest-common/pom.xml
+++ b/jest-common/pom.xml
@@ -82,11 +82,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
         </dependency>

--- a/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractAction.java
@@ -1,5 +1,7 @@
 package io.searchbox.action;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.LinkedHashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
@@ -10,17 +12,19 @@ import com.google.gson.JsonSyntaxException;
 import io.searchbox.annotations.JestId;
 import io.searchbox.client.JestResult;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.apache.commons.lang3.builder.ToStringBuilder;
+import io.searchbox.strings.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Field;
 import java.net.URLEncoder;
-import java.util.*;
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -173,10 +177,10 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
         StringBuilder sb = new StringBuilder();
 
         try {
-            if (StringUtils.isNotBlank(indexName)) {
+            if (!StringUtils.isBlank(indexName)) {
                 sb.append(URLEncoder.encode(indexName, CHARSET));
 
-                if (StringUtils.isNotBlank(typeName)) {
+                if (!StringUtils.isBlank(typeName)) {
                     sb.append("/").append(URLEncoder.encode(typeName, CHARSET));
                 }
             }
@@ -193,7 +197,7 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
         StringBuilder queryString = new StringBuilder();
 
         if (!cleanApiParameters.isEmpty()) {
-            queryString.append("/").append(StringUtils.join(cleanApiParameters, ","));
+            queryString.append("/").append(Joiner.on(',').join(cleanApiParameters));
         }
 
         queryString.append("?");
@@ -212,21 +216,15 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .appendSuper(super.toString())
-                .append("uri", getURI())
-                .append("method", getRestMethodName())
+        return MoreObjects.toStringHelper(this)
+                .add("uri", getURI())
+                .add("method", getRestMethodName())
                 .toString();
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .append(getURI())
-                .append(getRestMethodName())
-                .append(getHeaders())
-                .append(payload)
-                .toHashCode();
+        return Objects.hash(getURI(), getRestMethodName(), getHeaders(), payload);
     }
 
     @Override
@@ -242,12 +240,10 @@ public abstract class AbstractAction<T extends JestResult> implements Action<T> 
         }
 
         AbstractAction rhs = (AbstractAction) obj;
-        return new EqualsBuilder()
-                .append(getURI(), rhs.getURI())
-                .append(getRestMethodName(), rhs.getRestMethodName())
-                .append(getHeaders(), rhs.getHeaders())
-                .append(payload, rhs.payload)
-                .isEquals();
+        return Objects.equals(getURI(), rhs.getURI())
+                && Objects.equals(getRestMethodName(), rhs.getRestMethodName())
+                && Objects.equals(getHeaders(), rhs.getHeaders())
+                && Objects.equals(payload, rhs.payload);
     }
 
     public abstract String getRestMethodName();

--- a/jest-common/src/main/java/io/searchbox/action/AbstractDocumentTargetedAction.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractDocumentTargetedAction.java
@@ -1,7 +1,7 @@
 package io.searchbox.action;
 
 import io.searchbox.client.JestResult;
-import org.apache.commons.lang3.StringUtils;
+import io.searchbox.strings.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -39,7 +39,7 @@ public abstract class AbstractDocumentTargetedAction<T extends JestResult> exten
     protected String buildURI() {
         StringBuilder sb = new StringBuilder(super.buildURI());
 
-        if (StringUtils.isNotBlank(id)) {
+        if (!StringUtils.isBlank(id)) {
             try {
                 sb.append("/").append(URLEncoder.encode(id, CHARSET));
             } catch (UnsupportedEncodingException e) {

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiINodeActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiINodeActionBuilder.java
@@ -1,6 +1,7 @@
 package io.searchbox.action;
 
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Joiner;
+import com.google.common.base.Strings;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -33,7 +34,7 @@ public abstract class AbstractMultiINodeActionBuilder<T extends Action, K> exten
      * </pre>
      */
     public K addNode(String node) {
-        if (StringUtils.isNotEmpty(node)) {
+        if (!Strings.isNullOrEmpty(node)) {
             nodes.add(node);
         }
         return (K) this;
@@ -66,7 +67,7 @@ public abstract class AbstractMultiINodeActionBuilder<T extends Action, K> exten
 
     public String getJoinedNodes() {
         if (!nodes.isEmpty()) {
-            return StringUtils.join(nodes, ",");
+            return Joiner.on(',').join(nodes);
         } else {
             return "_all";
         }

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiIndexActionBuilder.java
@@ -1,11 +1,11 @@
 package io.searchbox.action;
 
+import com.google.common.base.Joiner;
 import io.searchbox.params.Parameters;
+
 import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.Set;
-
-import org.apache.commons.lang3.StringUtils;
 
 /**
  * @author cihat keser
@@ -44,7 +44,7 @@ public abstract class AbstractMultiIndexActionBuilder<T extends Action, K> exten
 
     public String getJoinedIndices() {
         if (indexNames.size() > 0) {
-            return StringUtils.join(indexNames, ",");
+            return Joiner.on(',').join(indexNames);
         } else {
             return "_all";
         }

--- a/jest-common/src/main/java/io/searchbox/action/AbstractMultiTypeActionBuilder.java
+++ b/jest-common/src/main/java/io/searchbox/action/AbstractMultiTypeActionBuilder.java
@@ -1,6 +1,6 @@
 package io.searchbox.action;
 
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Joiner;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -24,6 +24,6 @@ public abstract class AbstractMultiTypeActionBuilder<T extends Action, K> extend
     }
 
     public String getJoinedTypes() {
-        return StringUtils.join(indexTypes, ",");
+        return Joiner.on(',').join(indexTypes);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -1,6 +1,7 @@
 package io.searchbox.client;
 
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.gson.Gson;
@@ -8,7 +9,6 @@ import com.google.gson.GsonBuilder;
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.exception.NoServerConfiguredException;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,13 +48,13 @@ public abstract class AbstractJestClient implements JestClient {
         if (servers.equals(serverPoolReference.get().getServers())) {
             if (log.isDebugEnabled()) {
                 log.debug("Server pool already contains same list of servers: {}",
-                        StringUtils.join(servers, ","));
+                        Joiner.on(',').join(servers));
             }
             return;
         }
         if (log.isInfoEnabled()) {
             log.info("Setting server pool to a list of {} servers: [{}]",
-                      servers.size(), StringUtils.join(servers, ","));
+                      servers.size(), Joiner.on(',').join(servers));
         }
         serverPoolReference.set(new ServerPool(servers));
 

--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -1,5 +1,6 @@
 package io.searchbox.client;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -8,7 +9,6 @@ import com.google.gson.JsonParser;
 import io.searchbox.annotations.JestId;
 import io.searchbox.annotations.JestVersion;
 import io.searchbox.cloning.CloneUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,7 +148,7 @@ public class JestResult {
      */
     public String getSourceAsString() {
         List<String> sources = getSourceAsStringList();
-        return sources == null ? null : StringUtils.join(sources, ",");
+        return sources == null ? null : Joiner.on(',').join(sources);
     }
 
     /**

--- a/jest-common/src/main/java/io/searchbox/client/config/ClientConfig.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/ClientConfig.java
@@ -1,11 +1,10 @@
 package io.searchbox.client.config;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -122,21 +121,20 @@ public class ClientConfig {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .append(serverList)
-                .append(isMultiThreaded)
-                .append(isDiscoveryEnabled)
-                .append(isRequestCompressionEnabled)
-                .append(discoveryFrequency)
-                .append(discoveryFilter)
-                .append(connTimeout)
-                .append(readTimeout)
-                .append(discoveryFrequencyTimeUnit)
-                .append(maxConnectionIdleTime)
-                .append(maxConnectionIdleTimeDurationTimeUnit)
-                .append(gson)
-                .append(defaultSchemeForDiscoveredNodes)
-                .toHashCode();
+        return Objects.hash(
+                serverList,
+                isMultiThreaded,
+                isDiscoveryEnabled,
+                isRequestCompressionEnabled,
+                discoveryFrequency,
+                discoveryFilter,
+                connTimeout,
+                readTimeout,
+                discoveryFrequencyTimeUnit,
+                maxConnectionIdleTime,
+                maxConnectionIdleTimeDurationTimeUnit,
+                gson,
+                defaultSchemeForDiscoveredNodes);
     }
 
     @Override
@@ -152,21 +150,19 @@ public class ClientConfig {
         }
 
         ClientConfig rhs = (ClientConfig) obj;
-        return new EqualsBuilder()
-                .append(serverList, rhs.serverList)
-                .append(isMultiThreaded, rhs.isMultiThreaded)
-                .append(isDiscoveryEnabled, rhs.isDiscoveryEnabled)
-                .append(isRequestCompressionEnabled, rhs.isRequestCompressionEnabled)
-                .append(discoveryFrequency, rhs.discoveryFrequency)
-                .append(discoveryFilter, rhs.discoveryFilter)
-                .append(connTimeout, rhs.connTimeout)
-                .append(readTimeout, rhs.readTimeout)
-                .append(discoveryFrequencyTimeUnit, rhs.discoveryFrequencyTimeUnit)
-                .append(maxConnectionIdleTime, rhs.maxConnectionIdleTime)
-                .append(maxConnectionIdleTimeDurationTimeUnit, rhs.maxConnectionIdleTimeDurationTimeUnit)
-                .append(gson, rhs.gson)
-                .append(defaultSchemeForDiscoveredNodes, rhs.defaultSchemeForDiscoveredNodes)
-                .isEquals();
+        return Objects.equals(serverList, rhs.serverList)
+                && Objects.equals(isMultiThreaded, rhs.isMultiThreaded)
+                && Objects.equals(isDiscoveryEnabled, rhs.isDiscoveryEnabled)
+                && Objects.equals(isRequestCompressionEnabled, rhs.isRequestCompressionEnabled)
+                && Objects.equals(discoveryFrequency, rhs.discoveryFrequency)
+                && Objects.equals(discoveryFilter, rhs.discoveryFilter)
+                && Objects.equals(connTimeout, rhs.connTimeout)
+                && Objects.equals(readTimeout, rhs.readTimeout)
+                && Objects.equals(discoveryFrequencyTimeUnit, rhs.discoveryFrequencyTimeUnit)
+                && Objects.equals(maxConnectionIdleTime, rhs.maxConnectionIdleTime)
+                && Objects.equals(maxConnectionIdleTimeDurationTimeUnit, rhs.maxConnectionIdleTimeDurationTimeUnit)
+                && Objects.equals(gson, rhs.gson)
+                && Objects.equals(defaultSchemeForDiscoveredNodes, rhs.defaultSchemeForDiscoveredNodes);
     }
 
     protected static abstract class AbstractBuilder<T extends ClientConfig, K extends AbstractBuilder<T, K>> {

--- a/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
+++ b/jest-common/src/main/java/io/searchbox/client/config/discovery/NodeChecker.java
@@ -1,5 +1,6 @@
 package io.searchbox.client.config.discovery;
 
+import com.google.common.base.Joiner;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.util.concurrent.AbstractScheduledService;
@@ -14,7 +15,6 @@ import io.searchbox.client.config.ClientConfig;
 import io.searchbox.client.config.exception.CouldNotConnectException;
 import io.searchbox.cluster.NodesInfo;
 
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -113,7 +113,7 @@ public class NodeChecker extends AbstractScheduledService {
               }
             }
             if (log.isDebugEnabled()) {
-                log.debug("Discovered {} HTTP hosts: {}", httpHosts.size(), StringUtils.join(httpHosts, ","));
+                log.debug("Discovered {} HTTP hosts: {}", httpHosts.size(), Joiner.on(',').join(httpHosts));
             }
             discoveredServerList = httpHosts;
             client.setServers(discoveredServerList);
@@ -127,7 +127,7 @@ public class NodeChecker extends AbstractScheduledService {
         log.warn("Removing host {}", hostToRemove);
         discoveredServerList.remove(hostToRemove);
         if (log.isInfoEnabled()) {
-            log.info("Discovered server pool is now: {}", StringUtils.join(discoveredServerList, ","));
+            log.info("Discovered server pool is now: {}", Joiner.on(',').join(discoveredServerList));
         }
         if (!discoveredServerList.isEmpty()) {
           client.setServers(discoveredServerList);

--- a/jest-common/src/main/java/io/searchbox/cluster/Health.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/Health.java
@@ -3,7 +3,7 @@ package io.searchbox.cluster;
 import com.google.common.base.Preconditions;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.StringUtils;
+import io.searchbox.strings.StringUtils;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
@@ -51,7 +51,7 @@ public class Health extends GenericResultAbstractAction {
         StringBuilder sb = new StringBuilder("/_cluster/health/");
 
         try {
-            if (StringUtils.isNotBlank(indexName)) {
+            if (!StringUtils.isBlank(indexName)) {
                 sb.append(URLEncoder.encode(indexName, CHARSET));
             }
         } catch (UnsupportedEncodingException e) {

--- a/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/cluster/UpdateSettings.java
@@ -2,8 +2,6 @@ package io.searchbox.cluster;
 
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Allows to update cluster wide specific settings. Settings updated can either be persistent (applied cross restarts)
@@ -31,30 +29,6 @@ public class UpdateSettings extends GenericResultAbstractAction {
     @Override
     public String getRestMethodName() {
         return "PUT";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractAction.Builder<UpdateSettings, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Bulk.java
+++ b/jest-common/src/main/java/io/searchbox/core/Bulk.java
@@ -7,7 +7,7 @@ import io.searchbox.action.AbstractAction;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
+import io.searchbox.strings.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,13 +67,13 @@ public class Bulk extends AbstractAction<BulkResult> {
             Map<String, Map<String, String>> opMap = new LinkedHashMap<String, Map<String, String>>(1);
 
             Map<String, String> opDetails = new LinkedHashMap<String, String>(3);
-            if (StringUtils.isNotBlank(action.getId())) {
+            if (!StringUtils.isBlank(action.getId())) {
                 opDetails.put("_id", action.getId());
             }
-            if (StringUtils.isNotBlank(action.getIndex())) {
+            if (!StringUtils.isBlank(action.getIndex())) {
                 opDetails.put("_index", action.getIndex());
             }
-            if (StringUtils.isNotBlank(action.getType())) {
+            if (!StringUtils.isBlank(action.getType())) {
                 opDetails.put("_type", action.getType());
             }
 

--- a/jest-common/src/main/java/io/searchbox/core/BulkResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/BulkResult.java
@@ -6,12 +6,10 @@ import com.google.gson.JsonObject;
 
 import io.searchbox.client.JestResult;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author cihat.keser
@@ -135,32 +133,29 @@ public class BulkResult extends JestResult {
 
             BulkResultItem that = (BulkResultItem) o;
 
-            return new EqualsBuilder()
-                    .append(status, that.status)
-                    .append(operation, that.operation)
-                    .append(index, that.index)
-                    .append(type, that.type)
-                    .append(id, that.id)
-                    .append(error, that.error)
-                    .append(errorType, that.errorType)
-                    .append(errorReason, that.errorReason)
-                    .append(version, that.version)
-                    .isEquals();
+            return Objects.equals(status, that.status)
+                    && Objects.equals(operation, that.operation)
+                    && Objects.equals(index, that.index)
+                    && Objects.equals(type, that.type)
+                    && Objects.equals(id, that.id)
+                    && Objects.equals(error, that.error)
+                    && Objects.equals(errorType, that.errorType)
+                    && Objects.equals(errorReason, that.errorReason)
+                    && Objects.equals(version, that.version);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder(17, 37)
-                    .append(operation)
-                    .append(index)
-                    .append(type)
-                    .append(id)
-                    .append(status)
-                    .append(error)
-                    .append(errorType)
-                    .append(errorReason)
-                    .append(version)
-                    .toHashCode();
+            return Objects.hash(
+                    operation,
+                    index,
+                    type,
+                    id,
+                    status,
+                    error,
+                    errorType,
+                    errorReason,
+                    version);
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/core/Cat.java
+++ b/jest-common/src/main/java/io/searchbox/core/Cat.java
@@ -1,5 +1,6 @@
 package io.searchbox.core;
 
+import com.google.common.base.Joiner;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
@@ -9,8 +10,6 @@ import com.google.gson.JsonSyntaxException;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author Bartosz Polnik
@@ -60,13 +59,6 @@ public class Cat extends AbstractAction<CatResult> {
         } else {
             throw new JsonSyntaxException("Cat response did not contain a JSON Array");
         }
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .append(super.hashCode())
-                .toHashCode();
     }
 
     public static class IndicesBuilder extends AbstractMultiTypeActionBuilder<Cat, IndicesBuilder> implements CatBuilder {
@@ -126,7 +118,7 @@ public class Cat extends AbstractAction<CatResult> {
         @Override
         public String getJoinedIndices() {
             if (indexNames.size() > 0) {
-                return StringUtils.join(indexNames, ",");
+                return Joiner.on(',').join(indexNames);
             } else {
                 return null;
             }
@@ -152,7 +144,7 @@ public class Cat extends AbstractAction<CatResult> {
 
         @Override
         public String getJoinedIndices() {
-            return indexNames.size() > 0 ? StringUtils.join(indexNames, ",") : null;
+            return indexNames.size() > 0 ? Joiner.on(',').join(indexNames) : null;
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/core/Count.java
+++ b/jest-common/src/main/java/io/searchbox/core/Count.java
@@ -3,8 +3,6 @@ package io.searchbox.core;
 import com.google.gson.Gson;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author Dogukan Sonmez
@@ -37,30 +35,6 @@ public class Count extends AbstractAction<CountResult> {
     @Override
     public String getRestMethodName() {
         return "POST";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<Count, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
+++ b/jest-common/src/main/java/io/searchbox/core/DeleteByQuery.java
@@ -2,8 +2,6 @@ package io.searchbox.core;
 
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Delete By Query API  is removed in Elasticsearch version 2.0.
@@ -35,30 +33,6 @@ public class DeleteByQuery extends GenericResultAbstractAction {
     @Override
     public String getRestMethodName() {
         return "POST";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<DeleteByQuery, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Doc.java
+++ b/jest-common/src/main/java/io/searchbox/core/Doc.java
@@ -1,6 +1,6 @@
 package io.searchbox.core;
 
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Strings;
 
 import java.util.*;
 
@@ -37,10 +37,10 @@ public class Doc {
      * @param id
      */
     public Doc(String index, String type, String id) {
-        if(StringUtils.isEmpty(index)){
+        if(Strings.isNullOrEmpty(index)){
             throw new IllegalArgumentException("Required Index argument cannot be null or empty.");
         }
-        if(StringUtils.isEmpty(id)){
+        if(Strings.isNullOrEmpty(id)){
             throw new IllegalArgumentException("Required Id argument cannot be null or empty.");
         }
 
@@ -110,7 +110,7 @@ public class Doc {
 
         retval.put("_index", index);
 
-        if(StringUtils.isNotEmpty(type)) {
+        if(!Strings.isNullOrEmpty(type)) {
             retval.put("_type", type);
         }
 
@@ -120,7 +120,7 @@ public class Doc {
             retval.put("fields", fields);
         }
 
-        if(StringUtils.isNotEmpty(routing)){
+        if(!Strings.isNullOrEmpty(routing)){
             retval.put("_routing", routing);
         }
 

--- a/jest-common/src/main/java/io/searchbox/core/Explain.java
+++ b/jest-common/src/main/java/io/searchbox/core/Explain.java
@@ -1,8 +1,6 @@
 package io.searchbox.core;
 
 import io.searchbox.action.SingleResultAbstractDocumentTargetedAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author Dogukan Sonmez
@@ -24,30 +22,6 @@ public class Explain extends SingleResultAbstractDocumentTargetedAction {
     @Override
     protected String buildURI() {
         return super.buildURI() + "/_explain";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends SingleResultAbstractDocumentTargetedAction.Builder<Explain, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Index.java
+++ b/jest-common/src/main/java/io/searchbox/core/Index.java
@@ -3,8 +3,6 @@ package io.searchbox.core;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.action.SingleResultAbstractDocumentTargetedAction;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Collection;
 
@@ -42,30 +40,6 @@ public class Index extends SingleResultAbstractDocumentTargetedAction implements
         } else {
             return "index";
         }
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends SingleResultAbstractDocumentTargetedAction.Builder<Index, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/MultiGet.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiGet.java
@@ -6,8 +6,6 @@ import com.google.common.collect.Lists;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -56,30 +54,6 @@ public class MultiGet extends GenericResultAbstractAction {
     @Override
     public String getPathToResult() {
         return "docs/_source";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder {

--- a/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
+++ b/jest-common/src/main/java/io/searchbox/core/MultiSearch.java
@@ -3,13 +3,12 @@ package io.searchbox.core;
 import com.google.gson.Gson;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import io.searchbox.strings.StringUtils;
 
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * @author Dogukan Sonmez
@@ -49,7 +48,7 @@ public class MultiSearch extends AbstractAction<MultiSearchResult> {
         StringBuilder sb = new StringBuilder();
         for (Search search : searches) {
             sb.append("{\"index\" : \"").append(search.getIndex());
-            if (StringUtils.isNotBlank(search.getType())) {
+            if (!StringUtils.isBlank(search.getType())) {
                 sb.append("\", \"type\" : \"").append(search.getType());
             }
             sb.append(getParameter(search, "ignore_unavailable"));
@@ -82,10 +81,7 @@ public class MultiSearch extends AbstractAction<MultiSearchResult> {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(searches)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), searches);
     }
 
     @Override
@@ -101,10 +97,7 @@ public class MultiSearch extends AbstractAction<MultiSearchResult> {
         }
 
         MultiSearch rhs = (MultiSearch) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(searches, rhs.searches)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(searches, rhs.searches);
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<MultiSearch, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Percolate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Percolate.java
@@ -1,8 +1,6 @@
 package io.searchbox.core;
 
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Use this action to query on registered percolaters.
@@ -29,30 +27,6 @@ public class Percolate extends GenericResultAbstractAction {
     @Override
     protected String buildURI() {
         return super.buildURI() + "/_percolate";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<Percolate, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Search.java
+++ b/jest-common/src/main/java/io/searchbox/core/Search.java
@@ -4,9 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
-
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+import java.util.Objects;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
@@ -192,10 +190,7 @@ public class Search extends AbstractAction<SearchResult> {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(query)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), query, sortList, includePatternList, excludePatternList);
     }
 
     @Override
@@ -211,13 +206,11 @@ public class Search extends AbstractAction<SearchResult> {
         }
 
         Search rhs = (Search) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(query, rhs.query)
-                .append(sortList, rhs.sortList)
-                .append(includePatternList, rhs.includePatternList)
-                .append(excludePatternList, rhs.excludePatternList)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(query, rhs.query)
+                && Objects.equals(sortList, rhs.sortList)
+                && Objects.equals(includePatternList, rhs.includePatternList)
+                && Objects.equals(excludePatternList, rhs.excludePatternList);
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<Search, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -8,8 +8,6 @@ import io.searchbox.client.JestResult;
 import io.searchbox.cloning.CloneUtils;
 import io.searchbox.core.search.aggregation.MetricAggregation;
 import io.searchbox.core.search.aggregation.RootAggregation;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.*;
 
@@ -293,15 +291,14 @@ public class SearchResult extends JestResult {
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(source)
-                    .append(explanation)
-                    .append(highlight)
-                    .append(sort)
-                    .append(index)
-                    .append(type)
-                    .append(id)
-                    .toHashCode();
+            return Objects.hash(
+                    source,
+                    explanation,
+                    highlight,
+                    sort,
+                    index,
+                    type,
+                    id);
         }
 
         @Override
@@ -317,15 +314,13 @@ public class SearchResult extends JestResult {
             }
 
             Hit rhs = (Hit) obj;
-            return new EqualsBuilder()
-                    .append(source, rhs.source)
-                    .append(explanation, rhs.explanation)
-                    .append(highlight, rhs.highlight)
-                    .append(sort, rhs.sort)
-                    .append(index, rhs.index)
-                    .append(type, rhs.type)
-                    .append(id, rhs.id)
-                    .isEquals();
+            return Objects.equals(source, rhs.source)
+                    && Objects.equals(explanation, rhs.explanation)
+                    && Objects.equals(highlight, rhs.highlight)
+                    && Objects.equals(sort, rhs.sort)
+                    && Objects.equals(index, rhs.index)
+                    && Objects.equals(type, rhs.type)
+                    && Objects.equals(id, rhs.id);
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
@@ -1,13 +1,11 @@
 package io.searchbox.core;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Joiner;
 import com.google.gson.JsonObject;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author ferhat
@@ -50,30 +48,6 @@ public class SearchScroll extends GenericResultAbstractAction {
         return "hits/hits/_source";
     }
 
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
-
     public static class Builder extends AbstractMultiIndexActionBuilder<SearchScroll, Builder> {
 
         private final String scrollId;
@@ -89,7 +63,7 @@ public class SearchScroll extends GenericResultAbstractAction {
         @Override
         public String getJoinedIndices() {
             if (indexNames.size() > 0) {
-                return StringUtils.join(indexNames, ",");
+                return Joiner.on(',').join(indexNames);
             } else {
                 return null;
             }

--- a/jest-common/src/main/java/io/searchbox/core/Suggest.java
+++ b/jest-common/src/main/java/io/searchbox/core/Suggest.java
@@ -3,8 +3,6 @@ package io.searchbox.core;
 import com.google.gson.Gson;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiTypeActionBuilder;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 public class Suggest extends AbstractAction<SuggestResult> {
 
@@ -36,30 +34,6 @@ public class Suggest extends AbstractAction<SuggestResult> {
     @Override
     protected String buildURI() {
         return super.buildURI() + "/_suggest";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractMultiTypeActionBuilder<Suggest, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/SuggestResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SuggestResult.java
@@ -3,12 +3,11 @@ package io.searchbox.core;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 import io.searchbox.client.JestResult;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author cihat keser
@@ -50,12 +49,11 @@ public class SuggestResult extends JestResult {
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(text)
-                    .append(offset)
-                    .append(length)
-                    .append(options)
-                    .toHashCode();
+            return Objects.hash(
+                    text,
+                    offset,
+                    length,
+                    options);
         }
 
         @Override
@@ -71,12 +69,10 @@ public class SuggestResult extends JestResult {
             }
 
             Suggestion rhs = (Suggestion) obj;
-            return new EqualsBuilder()
-                    .append(text, rhs.text)
-                    .append(offset, rhs.offset)
-                    .append(length, rhs.length)
-                    .append(options, rhs.options)
-                    .isEquals();
+            return Objects.equals(text, rhs.text)
+                    && Objects.equals(offset, rhs.offset)
+                    && Objects.equals(length, rhs.length)
+                    && Objects.equals(options, rhs.options);
         }
     }
 

--- a/jest-common/src/main/java/io/searchbox/core/Update.java
+++ b/jest-common/src/main/java/io/searchbox/core/Update.java
@@ -3,8 +3,6 @@ package io.searchbox.core;
 import io.searchbox.action.BulkableAction;
 import io.searchbox.action.SingleResultAbstractDocumentTargetedAction;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author Dogukan Sonmez
@@ -37,30 +35,6 @@ public class Update extends SingleResultAbstractDocumentTargetedAction implement
     @Override
     public String getPathToResult() {
         return "ok";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends SingleResultAbstractDocumentTargetedAction.Builder<Update, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/Validate.java
+++ b/jest-common/src/main/java/io/searchbox/core/Validate.java
@@ -1,8 +1,6 @@
 package io.searchbox.core;
 
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author Dogukan Sonmez
@@ -32,30 +30,6 @@ public class Validate extends GenericResultAbstractAction {
     @Override
     public String getPathToResult() {
         return "valid";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<Validate, Builder> {

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Aggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Aggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -34,17 +34,12 @@ public abstract class Aggregation {
             return false;
         }
         Aggregation rhs = (Aggregation) obj;
-        return new EqualsBuilder()
-                .append(name, rhs.name)
-                .isEquals();
+        return Objects.equals(name, rhs.name);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(name)
-                .toHashCode();
+        return Objects.hash(name);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Bucket.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Bucket.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -36,18 +36,12 @@ public abstract class Bucket extends MetricAggregation {
             return false;
         }
         Bucket rhs = (Bucket) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(count, rhs.count)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(count, rhs.count);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(count)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), count);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/CardinalityAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -40,18 +40,12 @@ public class CardinalityAggregation extends MetricAggregation {
         }
 
         CardinalityAggregation rhs = (CardinalityAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(cardinality, rhs.cardinality)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(cardinality, rhs.cardinality);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(cardinality)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), cardinality);
     }
 }
 

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateHistogramAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -74,18 +73,12 @@ public class DateHistogramAggregation extends BucketAggregation {
             }
 
             DateHistogram rhs = (DateHistogram) obj;
-            return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(timeAsString, rhs.timeAsString)
-                    .isEquals();
+            return super.equals(obj) && Objects.equals(timeAsString, rhs.timeAsString);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(timeAsString)
-                    .toHashCode();
+            return Objects.hash(super.hashCode(), timeAsString);
         }
     }
 
@@ -102,17 +95,11 @@ public class DateHistogramAggregation extends BucketAggregation {
         }
 
         DateHistogramAggregation rhs = (DateHistogramAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(dateHistograms, rhs.dateHistograms)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(dateHistograms, rhs.dateHistograms);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(dateHistograms)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), dateHistograms);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/DateRangeAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -83,19 +82,12 @@ public class DateRangeAggregation extends BucketAggregation {
             }
 
             DateRange rhs = (DateRange) o;
-            return new EqualsBuilder()
-                    .append(fromAsString, rhs.fromAsString)
-                    .append(toAsString, rhs.toAsString)
-                    .isEquals();
+            return Objects.equals(fromAsString, rhs.fromAsString) && Objects.equals(toAsString, rhs.toAsString);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(fromAsString)
-                    .append(toAsString)
-                    .toHashCode();
+            return Objects.hash(super.hashCode(), fromAsString, toAsString);
         }
     }
 
@@ -109,15 +101,11 @@ public class DateRangeAggregation extends BucketAggregation {
         }
 
         DateRangeAggregation rhs = (DateRangeAggregation) o;
-        return new EqualsBuilder()
-                .append(getBuckets(), rhs.getBuckets())
-                .isEquals();
+        return Objects.equals(getBuckets(), rhs.getBuckets());
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .append(getBuckets())
-                .toHashCode();
+        return Objects.hash(getBuckets());
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ExtendedStatsAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -59,21 +59,17 @@ public class ExtendedStatsAggregation extends StatsAggregation {
         }
 
         ExtendedStatsAggregation rhs = (ExtendedStatsAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(stdDeviation, rhs.stdDeviation)
-                .append(sumOfSquares, rhs.sumOfSquares)
-                .append(variance, rhs.variance)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(stdDeviation, rhs.stdDeviation)
+                && Objects.equals(sumOfSquares, rhs.sumOfSquares)
+                && Objects.equals(variance, rhs.variance);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(sumOfSquares)
-                .append(variance)
-                .append(stdDeviation)
-                .toHashCode();
+        return Objects.hash(super.hashCode(),
+                sumOfSquares,
+                variance,
+                stdDeviation);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FilterAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
 
@@ -18,29 +18,8 @@ public class FilterAggregation extends Bucket {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        FilterAggregation rhs = (FilterAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
-
-    @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(TYPE)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), TYPE);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/FiltersAggregation.java
@@ -2,8 +2,6 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -11,6 +9,7 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
 
@@ -83,18 +82,12 @@ public class FiltersAggregation extends BucketAggregation {
         }
 
         FiltersAggregation rhs = (FiltersAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(bucketMap, rhs.bucketMap)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(bucketMap, rhs.bucketMap);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(bucketMap)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), bucketMap);
     }
 }
 

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoBoundsAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -73,23 +73,19 @@ public class GeoBoundsAggregation extends MetricAggregation {
         }
 
         GeoBoundsAggregation rhs = (GeoBoundsAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(topLeftLat, rhs.topLeftLat)
-                .append(topLeftLon, rhs.topLeftLon)
-                .append(bottomRightLat, rhs.bottomRightLat)
-                .append(bottomRightLon, rhs.bottomRightLon)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(topLeftLat, rhs.topLeftLat)
+                && Objects.equals(topLeftLon, rhs.topLeftLon)
+                && Objects.equals(bottomRightLat, rhs.bottomRightLat)
+                && Objects.equals(bottomRightLon, rhs.bottomRightLon);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(bottomRightLat)
-                .append(bottomRightLon)
-                .append(topLeftLat)
-                .append(topLeftLon)
-                .toHashCode();
+        return Objects.hash(super.hashCode(),
+                bottomRightLat,
+                bottomRightLon,
+                topLeftLat,
+                topLeftLon);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoDistanceAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -57,17 +56,11 @@ public class GeoDistanceAggregation extends BucketAggregation {
         }
 
         GeoDistanceAggregation rhs = (GeoDistanceAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(geoDistances, rhs.geoDistances)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(geoDistances, rhs.geoDistances);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(geoDistances)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), geoDistances);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoHashGridAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/GeoHashGridAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -67,18 +66,12 @@ public class GeoHashGridAggregation extends BucketAggregation{
             }
 
             GeoHashGrid rhs = (GeoHashGrid) obj;
-            return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(key, rhs.key)
-                    .isEquals();
+            return super.equals(obj) && Objects.equals(key, rhs.key);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(key)
-                    .toHashCode();
+            return Objects.hash(super.hashCode(), key);
         }
     }
 
@@ -95,17 +88,11 @@ public class GeoHashGridAggregation extends BucketAggregation{
         }
 
         GeoHashGridAggregation rhs = (GeoHashGridAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(geoHashGrids, rhs.geoHashGrids)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(geoHashGrids, rhs.geoHashGrids);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(geoHashGrids)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), geoHashGrids);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/HistogramAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -68,18 +67,12 @@ public class HistogramAggregation extends BucketAggregation {
             }
 
             Histogram rhs = (Histogram) obj;
-            return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(key, rhs.key)
-                    .isEquals();
+            return super.equals(obj) && Objects.equals(key, rhs.key);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(key)
-                    .toHashCode();
+            return Objects.hash(super.hashCode(), key);
         }
     }
 
@@ -96,17 +89,11 @@ public class HistogramAggregation extends BucketAggregation {
         }
 
         HistogramAggregation rhs = (HistogramAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(histograms, rhs.histograms)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(histograms, rhs.histograms);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(histograms)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), histograms);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Ipv4RangeAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -78,22 +77,15 @@ public class Ipv4RangeAggregation extends BucketAggregation{
             }
 
             IpRange rhs = (IpRange) o;
-            return new EqualsBuilder()
-                    .append(count, rhs.count)
-                    .append(from, rhs.from)
-                    .append(to, rhs.to)
-                    .append(key, rhs.key)
-                    .isEquals();
+            return Objects.equals(count, rhs.count)
+                    && Objects.equals(from, rhs.from)
+                    && Objects.equals(to, rhs.to)
+                    && Objects.equals(key, rhs.key);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(count)
-                    .append(from)
-                    .append(to)
-                    .append(key)
-                    .toHashCode();
+            return Objects.hash(count, from, to, key);
         }
     }
 
@@ -110,17 +102,11 @@ public class Ipv4RangeAggregation extends BucketAggregation{
         }
 
         Ipv4RangeAggregation rhs = (Ipv4RangeAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(ranges, rhs.ranges)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(ranges, rhs.ranges);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(ranges)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), ranges);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MaxAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MaxAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -22,30 +22,10 @@ public class MaxAggregation extends SingleValueAggregation {
         return getValue();
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        MaxAggregation rhs = (MaxAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(TYPE)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), TYPE);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MinAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MinAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -23,28 +23,7 @@ public class MinAggregation extends SingleValueAggregation {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        MinAggregation rhs = (MinAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
-
-    @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(TYPE)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), TYPE);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/MissingAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
 
@@ -39,17 +39,11 @@ public class MissingAggregation extends MetricAggregation {
         }
 
         MissingAggregation rhs = (MissingAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(missing, rhs.missing)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(missing, rhs.missing);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(missing)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), missing);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentileRanksAggregation.java
@@ -2,11 +2,10 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUES;
 
@@ -49,18 +48,12 @@ public class PercentileRanksAggregation extends MetricAggregation {
         }
 
         PercentileRanksAggregation rhs = (PercentileRanksAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(percentileRanks, rhs.percentileRanks)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(percentileRanks, rhs.percentileRanks);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(percentileRanks)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), percentileRanks);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/PercentilesAggregation.java
@@ -2,11 +2,10 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -47,18 +46,12 @@ public class PercentilesAggregation extends MetricAggregation {
         }
 
         PercentilesAggregation rhs = (PercentilesAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(percentiles, rhs.percentiles)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(percentiles, rhs.percentiles);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(percentiles)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), percentiles);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/Range.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/Range.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * Represents data range defined by two limits (a lower limit called from and an upper limit called to) in a bucket.
@@ -35,19 +35,13 @@ public class Range extends Bucket {
         }
 
         Range rhs = (Range) o;
-        return new EqualsBuilder()
-                .append(count, rhs.count)
-                .append(from, rhs.from)
-                .append(to, rhs.to)
-                .isEquals();
+        return Objects.equals(count, rhs.count)
+                && Objects.equals(from, rhs.from)
+                && Objects.equals(to, rhs.to);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .append(count)
-                .append(from)
-                .append(to)
-                .toHashCode();
+        return Objects.hash(count, from, to);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/RangeAggregation.java
@@ -2,11 +2,10 @@ package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -55,17 +54,11 @@ public class RangeAggregation extends BucketAggregation {
         }
 
         RangeAggregation rhs = (RangeAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(ranges, rhs.ranges)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(ranges, rhs.ranges);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(ranges)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), ranges);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/RootAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/RootAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * Place holder class used to represent the root aggregation
@@ -16,29 +16,9 @@ public class RootAggregation extends MetricAggregation {
         super(name, root);
     }
 
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        RootAggregation rhs = (RootAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append("root")
-                .toHashCode();
+        return Objects.hash(super.hashCode(), "root");
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ScriptedMetricAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -20,29 +20,8 @@ public class ScriptedMetricAggregation extends SingleValueAggregation {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        ScriptedMetricAggregation rhs = (ScriptedMetricAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
-
-    @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(TYPE)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), TYPE);
     }
 
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SignificantTermsAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -94,22 +93,15 @@ public class SignificantTermsAggregation extends BucketAggregation {
             }
 
             SignificantTerm rhs = (SignificantTerm) obj;
-            return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(key, rhs.key)
-                    .append(score, rhs.score)
-                    .append(backgroundCount, rhs.backgroundCount)
-                    .isEquals();
+            return super.equals(obj)
+                    && Objects.equals(key, rhs.key)
+                    && Objects.equals(score, rhs.score)
+                    && Objects.equals(backgroundCount, rhs.backgroundCount);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .appendSuper(super.hashCode())
-                    .append(backgroundCount)
-                    .append(key)
-                    .append(score)
-                    .toHashCode();
+            return Objects.hash(super.hashCode(), backgroundCount, key, score);
         }
     }
 
@@ -126,19 +118,13 @@ public class SignificantTermsAggregation extends BucketAggregation {
         }
 
         SignificantTermsAggregation rhs = (SignificantTermsAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(totalCount, rhs.totalCount)
-                .append(significantTerms, rhs.significantTerms)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(totalCount, rhs.totalCount)
+                && Objects.equals(significantTerms, rhs.significantTerms);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(totalCount)
-                .append(significantTerms)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), totalCount, significantTerms);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SingleValueAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -40,17 +40,11 @@ public abstract class SingleValueAggregation extends MetricAggregation {
         }
 
         SingleValueAggregation rhs = (SingleValueAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(value, rhs.value)
-                .isEquals();
+        return super.equals(obj) && Objects.equals(value, rhs.value);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(value)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), value);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/StatsAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.*;
 
@@ -77,25 +77,21 @@ public class StatsAggregation extends MetricAggregation {
         }
 
         StatsAggregation rhs = (StatsAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(count, rhs.count)
-                .append(min, rhs.min)
-                .append(max, rhs.max)
-                .append(avg, rhs.avg)
-                .append(sum, rhs.sum)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(count, rhs.count)
+                && Objects.equals(min, rhs.min)
+                && Objects.equals(max, rhs.max)
+                && Objects.equals(avg, rhs.avg)
+                && Objects.equals(sum, rhs.sum);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(count)
-                .append(avg)
-                .append(max)
-                .append(min)
-                .append(sum)
-                .toHashCode();
+        return Objects.hash(super.hashCode(),
+                count,
+                avg,
+                max,
+                min,
+                sum);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/SumAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/SumAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author cfstout
@@ -20,28 +20,7 @@ public class SumAggregation extends SingleValueAggregation {
     }
 
     @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        SumAggregation rhs = (SumAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
-    }
-
-    @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(TYPE)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), TYPE);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/TermsAggregation.java
@@ -3,11 +3,10 @@ package io.searchbox.core.search.aggregation;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.BUCKETS;
 import static io.searchbox.core.search.aggregation.AggregationField.DOC_COUNT;
@@ -100,20 +99,14 @@ public class TermsAggregation extends BucketAggregation {
             }
 
             Entry rhs = (Entry) obj;
-            return new EqualsBuilder()
-                    .appendSuper(super.equals(obj))
-                    .append(key, rhs.key)
-                    .append(keyAsString, rhs.keyAsString)
-                    .isEquals();
+            return super.equals(obj)
+                    && Objects.equals(key, rhs.key)
+                    && Objects.equals(keyAsString, rhs.keyAsString);
         }
 
         @Override
         public int hashCode() {
-            return new HashCodeBuilder()
-                    .append(getCount())
-                    .append(getKey())
-                    .append(keyAsString)
-                    .toHashCode();
+            return Objects.hash(getCount(), getKey(), keyAsString);
         }
     }
 
@@ -130,21 +123,17 @@ public class TermsAggregation extends BucketAggregation {
         }
 
         TermsAggregation rhs = (TermsAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(buckets, rhs.buckets)
-                .append(docCountErrorUpperBound, rhs.docCountErrorUpperBound)
-                .append(sumOtherDocCount, rhs.sumOtherDocCount)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(buckets, rhs.buckets)
+                && Objects.equals(docCountErrorUpperBound, rhs.docCountErrorUpperBound)
+                && Objects.equals(sumOtherDocCount, rhs.sumOtherDocCount);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(docCountErrorUpperBound)
-                .append(sumOtherDocCount)
-                .append(buckets)
-                .toHashCode();
+        return Objects.hash(super.hashCode(),
+                docCountErrorUpperBound,
+                sumOtherDocCount,
+                buckets);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/ValueCountAggregation.java
@@ -1,8 +1,8 @@
 package io.searchbox.core.search.aggregation;
 
 import com.google.gson.JsonObject;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 import static io.searchbox.core.search.aggregation.AggregationField.VALUE;
 
@@ -37,17 +37,12 @@ public class ValueCountAggregation extends MetricAggregation {
         }
 
         ValueCountAggregation rhs = (ValueCountAggregation) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(valueCount, rhs.valueCount)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(valueCount, rhs.valueCount);
     }
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .append(valueCount)
-                .toHashCode();
+        return Objects.hash(super.hashCode(), valueCount);
     }
 }

--- a/jest-common/src/main/java/io/searchbox/indices/Analyze.java
+++ b/jest-common/src/main/java/io/searchbox/indices/Analyze.java
@@ -3,8 +3,6 @@ package io.searchbox.indices;
 import com.google.gson.Gson;
 import io.searchbox.action.AbstractAction;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,30 +32,6 @@ public class Analyze extends GenericResultAbstractAction {
     @Override
     public String getRestMethodName() {
         return "POST";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractAction.Builder<Analyze, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/CreateIndex.java
+++ b/jest-common/src/main/java/io/searchbox/indices/CreateIndex.java
@@ -1,8 +1,8 @@
 package io.searchbox.indices;
 
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
+
+import java.util.Objects;
 
 /**
  * @author Dogukan Sonmez
@@ -29,9 +29,7 @@ public class CreateIndex extends GenericResultAbstractAction {
 
     @Override
     public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
+        return Objects.hash(super.hashCode(), indexName, payload);
     }
 
     @Override
@@ -47,11 +45,9 @@ public class CreateIndex extends GenericResultAbstractAction {
         }
 
         CreateIndex rhs = (CreateIndex) obj;
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .append(indexName, rhs.indexName)
-                .append(payload, rhs.payload)
-                .isEquals();
+        return super.equals(obj)
+                && Objects.equals(indexName, rhs.indexName)
+                && Objects.equals(payload, rhs.payload);
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<CreateIndex, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/aliases/AliasMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/AliasMapping.java
@@ -1,6 +1,6 @@
 package io.searchbox.indices.aliases;
 
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Joiner;
 
 import java.util.*;
 
@@ -30,11 +30,11 @@ public abstract class AliasMapping {
             }
 
             if (searchRouting.size() > 0) {
-                paramsMap.put("search_routing", StringUtils.join(searchRouting, ","));
+                paramsMap.put("search_routing", Joiner.on(',').join(searchRouting));
             }
 
             if (indexRouting.size() > 0) {
-                paramsMap.put("index_routing", StringUtils.join(indexRouting, ","));
+                paramsMap.put("index_routing", Joiner.on(',').join(indexRouting));
             }
 
             Map<String, Object> actionMap = new LinkedHashMap<String, Object>();

--- a/jest-common/src/main/java/io/searchbox/indices/aliases/ModifyAliases.java
+++ b/jest-common/src/main/java/io/searchbox/indices/aliases/ModifyAliases.java
@@ -2,8 +2,6 @@ package io.searchbox.indices.aliases;
 
 import com.google.common.collect.ImmutableMap;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 import java.util.Collection;
 import java.util.LinkedList;
@@ -34,30 +32,6 @@ public class ModifyAliases extends GenericResultAbstractAction {
     @Override
     public String getRestMethodName() {
         return "POST";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<ModifyAliases, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
+++ b/jest-common/src/main/java/io/searchbox/indices/mapping/PutMapping.java
@@ -1,8 +1,6 @@
 package io.searchbox.indices.mapping;
 
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * @author ferhat
@@ -27,30 +25,6 @@ public class PutMapping extends GenericResultAbstractAction {
     @Override
     public String getRestMethodName() {
         return "PUT";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends GenericResultAbstractAction.Builder<PutMapping, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/settings/UpdateSettings.java
+++ b/jest-common/src/main/java/io/searchbox/indices/settings/UpdateSettings.java
@@ -1,8 +1,6 @@
 package io.searchbox.indices.settings;
 
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 /**
  * Change specific index level settings in real time.
@@ -20,30 +18,6 @@ public class UpdateSettings extends IndicesSettingsAbstractAction {
     @Override
     public String getRestMethodName() {
         return "PUT";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends AbstractMultiIndexActionBuilder<UpdateSettings, Builder> {

--- a/jest-common/src/main/java/io/searchbox/indices/template/PutTemplate.java
+++ b/jest-common/src/main/java/io/searchbox/indices/template/PutTemplate.java
@@ -1,8 +1,5 @@
 package io.searchbox.indices.template;
 
-import org.apache.commons.lang3.builder.EqualsBuilder;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-
 /**
  * @author asierdelpozo
  * @author cihat keser
@@ -19,30 +16,6 @@ public class PutTemplate extends TemplateAction {
     @Override
     public String getRestMethodName() {
         return "PUT";
-    }
-
-    @Override
-    public int hashCode() {
-        return new HashCodeBuilder()
-                .appendSuper(super.hashCode())
-                .toHashCode();
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-        if (obj == null) {
-            return false;
-        }
-        if (obj == this) {
-            return true;
-        }
-        if (obj.getClass() != getClass()) {
-            return false;
-        }
-
-        return new EqualsBuilder()
-                .appendSuper(super.equals(obj))
-                .isEquals();
     }
 
     public static class Builder extends TemplateAction.Builder<PutTemplate, Builder> {

--- a/jest-common/src/main/java/io/searchbox/snapshot/AbstractSnapshotAction.java
+++ b/jest-common/src/main/java/io/searchbox/snapshot/AbstractSnapshotAction.java
@@ -1,7 +1,7 @@
 package io.searchbox.snapshot;
 
+import com.google.common.base.Joiner;
 import io.searchbox.action.GenericResultAbstractAction;
-import org.apache.commons.lang3.StringUtils;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -75,7 +75,7 @@ public abstract class AbstractSnapshotAction extends GenericResultAbstractAction
             if (snapshots.isEmpty()) {
                 return "_all";
             } else {
-                return StringUtils.join(snapshots, ",");
+                return Joiner.on(',').join(snapshots);
             }
         }
     }

--- a/jest-common/src/main/java/io/searchbox/snapshot/GetSnapshotRepository.java
+++ b/jest-common/src/main/java/io/searchbox/snapshot/GetSnapshotRepository.java
@@ -1,6 +1,6 @@
 package io.searchbox.snapshot;
 
-import org.apache.commons.lang3.StringUtils;
+import com.google.common.base.Joiner;
 
 import java.util.Collection;
 import java.util.LinkedHashSet;
@@ -49,7 +49,7 @@ public class GetSnapshotRepository extends AbstractSnapshotRepositoryAction {
             if (repositories.isEmpty()) {
                 return "_all";
             } else {
-                return StringUtils.join(repositories, ",");
+                return Joiner.on(',').join(repositories);
             }
         }
     }

--- a/jest-common/src/main/java/io/searchbox/strings/StringUtils.java
+++ b/jest-common/src/main/java/io/searchbox/strings/StringUtils.java
@@ -1,0 +1,18 @@
+package io.searchbox.strings;
+
+public class StringUtils {
+    private StringUtils() {}
+
+    public static boolean isBlank(final CharSequence cs) {
+        int strLen;
+        if (cs == null || (strLen = cs.length()) == 0) {
+            return true;
+        }
+        for (int i = 0; i < strLen; i++) {
+            if (Character.isWhitespace(cs.charAt(i)) == false) {
+                return false;
+            }
+        }
+        return true;
+    }
+}

--- a/jest-common/src/test/java/io/searchbox/core/CatResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/CatResultTest.java
@@ -1,7 +1,6 @@
 package io.searchbox.core;
 
 import com.google.gson.Gson;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.assertArrayEquals;
@@ -40,7 +39,7 @@ public class CatResultTest {
     @Test
       public void shouldReturnArrayWithColumnNamesAndSingleResult() {
         Cat cat = new Cat.IndicesBuilder().build();
-        String reasonPhase = StringUtils.EMPTY;
+        String reasonPhase = "";
         CatResult catResult = cat.createNewElasticSearchResult(EXAMPLE_RESPONSE_SINGLE_ROWS, 200, reasonPhase, new Gson());
 
         assertArrayEquals(new String[][]{
@@ -52,7 +51,7 @@ public class CatResultTest {
     @Test
     public void shouldReturnArrayWithTwoResultsEventWhenColumnsWereReordered() {
         Cat cat = new Cat.IndicesBuilder().build();
-        String reasonPhase = StringUtils.EMPTY;
+        String reasonPhase = "";
         CatResult catResult = cat.createNewElasticSearchResult(EXAMPLE_RESPONSE_TWO_ROWS, 200, reasonPhase, new Gson());
 
         assertArrayEquals(new String[][]{

--- a/jest-common/src/test/java/io/searchbox/core/SearchScrollTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchScrollTest.java
@@ -1,9 +1,9 @@
 package io.searchbox.core;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import io.searchbox.action.Action;
-import org.apache.commons.lang3.StringUtils;
 import org.junit.Test;
 
 import static org.junit.Assert.*;
@@ -12,7 +12,7 @@ import static org.junit.Assert.*;
 public class SearchScrollTest {
     @Test
     public void methodIsGetIfScrollIdIsShort() {
-        String scrollId = StringUtils.leftPad("scrollId", SearchScroll.MAX_SCROLL_ID_LENGTH, 'x');
+        String scrollId = Strings.padStart("scrollId", SearchScroll.MAX_SCROLL_ID_LENGTH, 'x');
         Action searchScroll = new SearchScroll.Builder(scrollId, "1m").build();
         String uri = searchScroll.getURI();
 
@@ -24,7 +24,7 @@ public class SearchScrollTest {
 
     @Test
     public void methodIsPostIfScrollIdIsLong() {
-        String scrollId = StringUtils.leftPad("scrollId", 2000, 'x');
+        String scrollId = Strings.padStart("scrollId", 2000, 'x');
 
         JsonObject expectedResults = new JsonObject();
         expectedResults.addProperty("scroll_id", scrollId);

--- a/jest-droid/pom.xml
+++ b/jest-droid/pom.xml
@@ -77,11 +77,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-        </dependency>
-
-        <dependency>
             <groupId>org.elasticsearch</groupId>
             <artifactId>elasticsearch</artifactId>
         </dependency>

--- a/jest/src/main/java/io/searchbox/client/JestClientFactory.java
+++ b/jest/src/main/java/io/searchbox/client/JestClientFactory.java
@@ -1,13 +1,12 @@
 package io.searchbox.client;
 
+import com.google.common.base.Strings;
 import com.google.gson.Gson;
 import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.client.config.discovery.NodeChecker;
 import io.searchbox.client.config.idle.HttpReapableConnectionManager;
 import io.searchbox.client.config.idle.IdleConnectionReaper;
 import io.searchbox.client.http.JestHttpClient;
-
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHost;
 import org.apache.http.client.AuthCache;
 import org.apache.http.client.config.RequestConfig;
@@ -75,7 +74,7 @@ public class JestClientFactory {
         // set discovery (should be set after setting the httpClient on jestClient)
         if (httpClientConfig.isDiscoveryEnabled()) {
             log.info("Node Discovery enabled...");
-            if (StringUtils.isNotEmpty(httpClientConfig.getDiscoveryFilter())) {
+            if (!Strings.isNullOrEmpty(httpClientConfig.getDiscoveryFilter())) {
                 log.info("Node Discovery filtering nodes on \"{}\"", httpClientConfig.getDiscoveryFilter());
             }
             NodeChecker nodeChecker = createNodeChecker(client, httpClientConfig);

--- a/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/JestHttpClientTest.java
@@ -6,7 +6,6 @@ import io.searchbox.client.http.apache.HttpDeleteWithEntity;
 import io.searchbox.client.http.apache.HttpGetWithEntity;
 import io.searchbox.core.Search;
 import io.searchbox.core.search.sort.Sort;
-import org.apache.commons.io.IOUtils;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpVersion;
@@ -17,6 +16,7 @@ import org.apache.http.client.methods.*;
 import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicStatusLine;
+import org.apache.http.util.EntityUtils;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -198,7 +198,7 @@ public class JestHttpClientTest {
 
         // Extract Payload
         HttpEntity entity = ((HttpPost) request).getEntity();
-        String payload = IOUtils.toString(entity.getContent(), Charset.defaultCharset());
+        String payload = EntityUtils.toString(entity, Charset.defaultCharset());
 
         // Verify payload does not have a double
         assertFalse(payload.contains("1234.0"));

--- a/jest/src/test/java/io/searchbox/core/BulkIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/BulkIntegrationTest.java
@@ -7,7 +7,6 @@ import io.searchbox.client.config.HttpClientConfig;
 import io.searchbox.client.http.JestHttpClient;
 import io.searchbox.common.AbstractIntegrationTest;
 import io.searchbox.params.Parameters;
-import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.action.get.GetRequest;
 import org.elasticsearch.action.get.GetResponse;
 import org.elasticsearch.test.ESIntegTestCase;
@@ -228,7 +227,7 @@ public class BulkIntegrationTest extends AbstractIntegrationTest {
         source.put("user", "kimchy");
         Bulk bulk = new Bulk.Builder()
                 .addAction(new Index.Builder(source).index(index).type(type).id(id).build())
-                .addAction(new Update.Builder(StringUtils.chomp(script)).index(index).type(type).id(id).build())
+                .addAction(new Update.Builder(script).index(index).type(type).id(id).build())
                 .build();
 
         BulkResult result = client.execute(bulk);

--- a/jest/src/test/java/io/searchbox/indices/AnalyzeIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/indices/AnalyzeIntegrationTest.java
@@ -1,19 +1,19 @@
 package io.searchbox.indices;
 
+import com.google.common.io.Resources;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import io.searchbox.action.Action;
 import io.searchbox.client.JestResult;
 import io.searchbox.common.AbstractIntegrationTest;
-import org.apache.commons.io.FileUtils;
 import org.elasticsearch.test.ESIntegTestCase;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 
 /**
  * @author cihat keser
@@ -25,9 +25,7 @@ public class AnalyzeIntegrationTest extends AbstractIntegrationTest {
 
     @BeforeClass
     public static void setupOnce() throws IOException, URISyntaxException {
-        sample_book = FileUtils.readFileToString(new File(
-                Thread.currentThread().getContextClassLoader().getResource("io/searchbox/sample_book.json").toURI()
-        ));
+        sample_book = Resources.toString(Resources.getResource("io/searchbox/sample_book.json"), StandardCharsets.UTF_8);
         assertNotNull(sample_book);
     }
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,6 @@
         <gson.version>2.6.2</gson.version>
         <mockito.version>1.10.19</mockito.version>
 
-        <commonsLang.version>3.4</commonsLang.version>
         <commons-io.version>2.5</commons-io.version>
         <junit.version>4.12</junit.version>
         <jsonassert.version>1.4.0</jsonassert.version>
@@ -209,12 +208,6 @@
                 <groupId>com.google.code.gson</groupId>
                 <artifactId>gson</artifactId>
                 <version>${gson.version}</version>
-            </dependency>
-
-            <dependency>
-                <groupId>org.apache.commons</groupId>
-                <artifactId>commons-lang3</artifactId>
-                <version>${commonsLang.version}</version>
             </dependency>
 
             <!-- Http components -->


### PR DESCRIPTION
Apache Commons Lang3 and Google Guava share pretty much the same functionality.

This change set replaces uses of commons-lang3 (mainly `HashCodeBuilder` and `EqualsBuilder`)
with the respective functionality of the Java standard library (`Objects#hash(...)` and
`Objects#equals(...)`) or Google Guava (`Strings#isNullOrEmpty(...)`) and thus removes the
dependency on commons-lang3.