### PR TITLE
Try making Travis CI builds more stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 dist: trusty
 jdk:
-  - openjdk8
+  - oraclejdk8
 sudo: false
 env:
   global:

--- a/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/cluster/NodesStatsIntegrationTest.java
@@ -23,8 +23,7 @@ public class NodesStatsIntegrationTest extends AbstractIntegrationTest {
     @Override
     public void setUp() throws Exception {
         super.setUp();
-        ensureClusterSizeConsistency();
-        ensureClusterStateConsistency();
+        ensureFullyConnectedCluster();
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -514,12 +514,14 @@
                                     <excludes>
                                         <exclude>none</exclude>
                                     </excludes>
-                                    <argLine>-XX:+PrintGCDetails -Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Djava.net.preferIPv4Stack=true -Dtests.security.manager=false</argLine>
+                                    <argLine>-Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Djava.net.preferIPv4Stack=true -Dtests.security.manager=false</argLine>
+                                    <reuseForks>false</reuseForks>
                                 </configuration>
                             </execution>
                         </executions>
                         <configuration>
-                            <argLine>-XX:+PrintGCDetails -Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Dtests.security.manager=false</argLine>
+                            <argLine>-Xmx${tests.heap.size} -Xms${tests.heap.size} -Dtests.heap.size=${tests.heap.size} -Dtests.security.manager=false</argLine>
+                            <reuseForks>false</reuseForks>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
The builds on Travis CI are a bit flakey and from time to time fail for no apparent reason.

This PR tries to make the builds more stable by:
* Using the official Oracle JDK
* Not reusing JVMs in tests

The last change makes Travis CI builds dog-slow (~30 minutes vs. ~10 minutes) but at least it seems to reliably complete the builds.