### PR TITLE
Use Long instead of Integer for number of total results

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/SearchResult.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchResult.java
@@ -186,10 +186,10 @@ public class SearchResult extends JestResult {
         return retval;
     }
 
-    public Integer getTotal() {
-        Integer total = null;
+    public Long getTotal() {
+        Long total = null;
         JsonElement obj = getPath(PATH_TO_TOTAL);
-        if (obj != null) total = obj.getAsInt();
+        if (obj != null) total = obj.getAsLong();
         return total;
     }
 

--- a/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/SearchResultTest.java
@@ -102,9 +102,9 @@ public class SearchResultTest {
         searchResult.setJsonObject(new JsonParser().parse(json).getAsJsonObject());
         searchResult.setPathToResult("hits/hits/_source");
 
-        Integer total = searchResult.getTotal();
+        Long total = searchResult.getTotal();
         assertNotNull(total);
-        assertEquals(new Integer(1), total);
+        assertEquals(new Long(1L), total);
     }
 
     @Test
@@ -136,7 +136,7 @@ public class SearchResultTest {
         searchResult.setJsonObject(new JsonParser().parse(jsonWithoutTotal).getAsJsonObject());
         searchResult.setPathToResult("hits/hits/_source");
 
-        Integer total = searchResult.getTotal();
+        Long total = searchResult.getTotal();
         assertNull(total);
     }
 

--- a/jest/src/test/java/io/searchbox/core/MultiSearchIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/MultiSearchIntegrationTest.java
@@ -84,7 +84,7 @@ public class MultiSearchIntegrationTest extends AbstractIntegrationTest {
         SearchResult complexSearchResult = complexSearchResponse.searchResult;
         assertTrue(complexSearchResult.isSucceeded());
         assertNull(complexSearchResult.getErrorMessage());
-        assertEquals(Integer.valueOf(2), complexSearchResult.getTotal());
+        assertEquals(Long.valueOf(2L), complexSearchResult.getTotal());
         List<SearchResult.Hit<Comment, Void>> complexSearchHits = complexSearchResult.getHits(Comment.class);
         assertEquals(2, complexSearchHits.size());
 
@@ -94,7 +94,7 @@ public class MultiSearchIntegrationTest extends AbstractIntegrationTest {
         SearchResult simpleSearchResult = simpleSearchResponse.searchResult;
         assertTrue(simpleSearchResult.isSucceeded());
         assertNull(simpleSearchResult.getErrorMessage());
-        assertEquals(Integer.valueOf(3), simpleSearchResult.getTotal());
+        assertEquals(Long.valueOf(3L), simpleSearchResult.getTotal());
         List<SearchResult.Hit<Comment, Void>> simpleSearchHits = simpleSearchResult.getHits(Comment.class);
         assertEquals(3, simpleSearchHits.size());
 

--- a/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchIntegrationTest.java
@@ -169,7 +169,7 @@ public class SearchIntegrationTest extends AbstractIntegrationTest {
 
         JsonElement explanation = hits.get(0).getAsJsonObject().get("_explanation");
         assertNotNull(explanation);
-        assertEquals(new Integer(1), result.getTotal());
+        assertEquals(new Long(1L), result.getTotal());
     }
 
     @Test


### PR DESCRIPTION
The number of total search results can easily be larger than the maximum value of Integer (2,147,483,647) in big Elasticsearch setups.