### PR TITLE
Make JestClient auto-closable

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/AbstractJestClient.java
@@ -12,6 +12,7 @@ import io.searchbox.client.config.idle.IdleConnectionReaper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -63,7 +64,20 @@ public abstract class AbstractJestClient implements JestClient {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void shutdownClient() {
+        try {
+            close();
+        } catch (IOException e) {
+            log.error("Error while shutting down client", e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
         if (null != nodeChecker) {
             nodeChecker.stopAsync();
             nodeChecker.awaitTerminated();

--- a/jest-common/src/main/java/io/searchbox/client/JestClient.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestClient.java
@@ -3,6 +3,7 @@ package io.searchbox.client;
 
 import io.searchbox.action.Action;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.Set;
 
@@ -10,12 +11,16 @@ import java.util.Set;
 /**
  * @author Dogukan Sonmez
  */
-public interface JestClient {
+public interface JestClient extends Closeable {
 
     <T extends JestResult> T execute(Action<T> clientRequest) throws IOException;
 
     <T extends JestResult> void executeAsync(Action<T> clientRequest, JestResultHandler<? super T> jestResultHandler);
 
+    /**
+     * @deprecated Use {@link #close()} instead.
+     */
+    @Deprecated
     void shutdownClient();
 
     void setServers(Set<String> servers);

--- a/jest-droid/src/main/java/com/searchly/jestdroid/JestDroidClient.java
+++ b/jest-droid/src/main/java/com/searchly/jestdroid/JestDroidClient.java
@@ -69,10 +69,6 @@ public class JestDroidClient extends AbstractJestClient implements JestClient {
         throw new UnsupportedOperationException("Jest-droid does not yet support async execution, sorry!");
     }
 
-    public void shutdownClient() {
-        super.shutdownClient();
-    }
-
     protected HttpUriRequest constructHttpMethod(String methodName, String url, String payload, RequestConfig requestConfig) {
         HttpUriRequest httpUriRequest = null;
 

--- a/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
+++ b/jest/src/main/java/io/searchbox/client/http/JestHttpClient.java
@@ -97,17 +97,18 @@ public class JestHttpClient extends AbstractJestClient {
 
     @Override
     public void shutdownClient() {
-        super.shutdownClient();
         try {
-            asyncClient.close();
-        } catch (IOException ex) {
-            log.error("Exception occurred while shutting down the async client.", ex);
+            close();
+        } catch (IOException e) {
+            log.error("Exception occurred while shutting down the sync client.", e);
         }
-        try {
-            httpClient.close();
-        } catch (IOException ex) {
-            log.error("Exception occurred while shutting down the sync client.", ex);
-        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+        asyncClient.close();
+        httpClient.close();
     }
 
     protected <T extends JestResult> HttpUriRequest prepareRequest(final Action<T> clientRequest, final RequestConfig requestConfig) {

--- a/jest/src/test/java/io/searchbox/client/http/FailingProxyTest.java
+++ b/jest/src/test/java/io/searchbox/client/http/FailingProxyTest.java
@@ -44,7 +44,7 @@ public class FailingProxyTest {
 
     @After
     public void tearDown() throws IOException {
-        client.shutdownClient();
+        client.close();
         proxy.stop();
     }
 

--- a/jest/src/test/java/io/searchbox/common/AbstractIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/common/AbstractIntegrationTest.java
@@ -90,7 +90,7 @@ public abstract class AbstractIntegrationTest extends ESIntegTestCase {
     @After
     public void tearDown() throws Exception {
         super.tearDown();
-        client.shutdownClient();
+        client.close();
         client = null;
     }
 


### PR DESCRIPTION
By implementing the [`Closable`](https://docs.oracle.com/javase/8/docs/api/java/io/Closeable.html) interface, `JestClient` can now be used in a [try-with-resources](https://docs.oracle.com/javase/tutorial/essential/exceptions/tryResourceClose.html) block which automatically shuts down the client and its thread pool when exiting the try-block.