### PR TITLE
remove redundant code in restMethodNameMultipleClientRequest method

### DIFF
--- a/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
+++ b/jest-common/src/test/java/io/searchbox/action/AbstractActionTest.java
@@ -86,7 +86,6 @@ public class AbstractActionTest {
 
         Delete del = new Delete.Builder("1").index("twitter").type("tweet").build();
         assertEquals("DELETE", del.getRestMethodName());
-        assertEquals("GET", get.getRestMethodName());
     }
 
     @Test


### PR DESCRIPTION
remove redundant code in restMethodNameMultipleClientRequest method
`assertEquals("GET", get.getRestMethodName());` appears twice