### PR TITLE
Add toString in JestResult and use auto-closable

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -367,4 +367,11 @@ public class JestResult {
         return pathToResult == null ? null : pathToResult.split("/");
     }
 
+    @Override
+    public String toString() {
+        return "Result: "             + getJsonString()
+                + ", isSucceeded: "   + isSucceeded()
+                + ", response code: " + getResponseCode()
+                + ", error message: " + getErrorMessage();
+    }
 }

--- a/jest-common/src/test/java/io/searchbox/indices/script/CreateIndexedScriptTest.java
+++ b/jest-common/src/test/java/io/searchbox/indices/script/CreateIndexedScriptTest.java
@@ -78,10 +78,10 @@ public class CreateIndexedScriptTest {
     private File createTempGroovySnippetFile() throws IOException {
         File file = File.createTempFile("test", ".groovy");
         file.deleteOnExit();
-        FileWriter writer = new FileWriter(file);
-        writer.write(groovysnippet);
-        writer.close();
-        return file;
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(groovysnippet);
+            return file;
+        }
     }
 
     private JsonObject parseAsGson(String data) {

--- a/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
+++ b/jest/src/test/java/io/searchbox/client/http/FailingProxy.java
@@ -68,11 +68,11 @@ public class FailingProxy {
     }
 
     private static int getUnusedPort() throws IOException {
-        final Socket deadSocket = new Socket();
-        deadSocket.bind(null);
-        final int port = deadSocket.getLocalPort();
-        deadSocket.close();
-        return port;
+        try (Socket deadSocket = new Socket()) {
+            deadSocket.bind(null);
+            final int port = deadSocket.getLocalPort();
+            return port;
+        }
     }
 
     private class FailingSourceAdapter extends HttpFiltersSourceAdapter {


### PR DESCRIPTION
- Add toString method on JestResult class
- Use auto-closable in some classes to fix sonar issues

=====
toString methid in JestResult makes it easier for debuging so that we can print the whole jestResult object and is similar to UpdateByQueryResult toString method. Issues with auto-closable were reported by sonar(code quality tool) as the only 2 blocker issues (highest severity).