### PR TITLE
Bucket aggregation getBuckets() should be public.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/search/aggregation/BucketAggregation.java
+++ b/jest-common/src/main/java/io/searchbox/core/search/aggregation/BucketAggregation.java
@@ -13,5 +13,5 @@ public abstract class BucketAggregation extends Aggregation {
         super(name, root);
     }
 
-    abstract List<? extends Bucket> getBuckets();
+    public abstract List<? extends Bucket> getBuckets();
 }


### PR DESCRIPTION
Otherwise, if you're desigining APIs that work with any BucketAggregation subclass, you don't have a way without using things like reflection to get the buckets, keys, and counts regardless of specific aggregation type.

Signed-off-by: John Dimeo <dimeo@elderresearch.com>