### PR TITLE
Avoid unnecessary String round-trip on Hit binding

### DIFF
--- a/jest-common/src/main/java/io/searchbox/client/JestResult.java
+++ b/jest-common/src/main/java/io/searchbox/client/JestResult.java
@@ -267,8 +267,7 @@ public class JestResult {
         T obj = null;
         try {
 
-            String json = source.toString();
-            obj = gson.fromJson(json, type);
+            obj = gson.fromJson(source, type);
 
             // Check if JestId is visible
             Class clazz = type;


### PR DESCRIPTION
Some code in Jest serializes GSON JsonElement objects to String and back in order to use `GSON.fromJson`.
This code was written on or before 2013, see 
https://github.com/searchbox-io/Jest/blame/8ae435f2670af98cb0abc4867c4f9c5b524f374e/jest-common/src/main/java/io/searchbox/client/JestResult.java#L270

Since GSON 1.3 (around 2017), there is now an overload that allows you to use the GSON reflection binding from a JsonElement source input, avoiding this extra work of going to String and back.

This PR changes this use the new, more efficient, method. I checked the rest of the codebase and could not find any other instances of this issue.

I am reasonably sure that this will be identical in behaviour but should be quite a bit faster.

All unit tests pass.

