### PR TITLE
Fix Jest <-> native comparison link in root readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Jest is a Java HTTP Rest client for [ElasticSearch][es].
 
 ElasticSearch is an Open Source (Apache 2), Distributed, RESTful, Search Engine built on top of Apache Lucene.
 
-ElasticSearch already has a Java API which is also used by ElasticSearch internally, [but Jest fills a gap, it is the missing client for ElasticSearch Http Rest interface](#comparison-to-native-api).
+ElasticSearch already has a Java API which is also used by ElasticSearch internally, [but Jest fills a gap, it is the missing client for ElasticSearch Http Rest interface](jest/README.md#comparison-to-native-api).
 
 >Read great [introduction][ibm] to ElasticSearch and Jest from IBM Developer works.
 


### PR DESCRIPTION
This link is currently copied and pasted from `jest/README.md`. However, the link doesn't work in the root readme because that section doesn't exist. This updates the link to go to `jest/README.md` instead.