### PR TITLE
align httpclient version 4.0.1, 4.5.3 to 4.5.3

### DIFF
--- a/jest-droid/pom.xml
+++ b/jest-droid/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.0.1</version>
+            <version>4.5.3</version>
             <scope>provided</scope>
         </dependency>
 


### PR DESCRIPTION
align httpclient version to avoid inconsistent API behaviors