### PR TITLE
Change class returned by search scroll to be search result.

### DIFF
--- a/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
+++ b/jest-common/src/main/java/io/searchbox/core/SearchScroll.java
@@ -2,7 +2,9 @@ package io.searchbox.core;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Joiner;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import io.searchbox.action.AbstractAction;
 import io.searchbox.action.AbstractMultiIndexActionBuilder;
 import io.searchbox.action.GenericResultAbstractAction;
 import io.searchbox.client.config.ElasticsearchVersion;
@@ -11,13 +13,11 @@ import io.searchbox.params.Parameters;
 /**
  * @author ferhat
  */
-public class SearchScroll extends GenericResultAbstractAction {
+public class SearchScroll extends AbstractAction<SearchResult> {
     @VisibleForTesting
     static final int MAX_SCROLL_ID_LENGTH = 1900;
     private final String restMethodName;
     public static final String SCROLL_ID = "scroll_id";
-    public static final String COMMA = ",";
-
 
     protected SearchScroll(Builder builder) {
         super(builder);
@@ -31,6 +31,11 @@ public class SearchScroll extends GenericResultAbstractAction {
         } else {
             this.restMethodName = "GET";
         }
+    }
+
+    @Override
+    public SearchResult createNewElasticSearchResult(String responseBody, int statusCode, String reasonPhrase, Gson gson) {
+        return createNewElasticSearchResult(new SearchResult(gson), responseBody, statusCode, reasonPhrase, gson);
     }
 
     @Override

--- a/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
+++ b/jest/src/test/java/io/searchbox/core/SearchScrollIntegrationTest.java
@@ -46,7 +46,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
                 .addSort(new Sort("code"))
                 .setParameter(Parameters.SCROLL, "5m")
                 .build();
-        JestResult result = client.execute(search);
+        SearchResult result = client.execute(search);
         assertTrue(result.getErrorMessage(), result.isSucceeded());
         JsonArray hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
         assertEquals(
@@ -81,8 +81,8 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
 
         // clear a single scroll id
         ClearScroll clearScroll = new ClearScroll.Builder().addScrollId(scrollId).build();
-        result = client.execute(clearScroll);
-        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        JestResult clearResult = client.execute(clearScroll);
+        assertTrue(clearResult.getErrorMessage(), clearResult.isSucceeded());
     }
 
     @Test
@@ -103,7 +103,7 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
             .addSort(new Sort("code"))
             .setParameter(Parameters.SCROLL, "5m")
             .build();
-        JestResult result = client.execute(search);
+        SearchResult result = client.execute(search);
         assertTrue(result.getErrorMessage(), result.isSucceeded());
         JsonArray hits = result.getJsonObject().getAsJsonObject("hits").getAsJsonArray("hits");
         assertEquals(
@@ -138,8 +138,8 @@ public class SearchScrollIntegrationTest extends AbstractIntegrationTest {
 
         // clear all scroll ids
         ClearScroll clearScroll = new ClearScroll.Builder().build();
-        result = client.execute(clearScroll);
-        assertTrue(result.getErrorMessage(), result.isSucceeded());
+        JestResult clearResult = client.execute(clearScroll);
+        assertTrue(clearResult.getErrorMessage(), clearResult.isSucceeded());
     }
 
 }


### PR DESCRIPTION
Allow you to use the getHits functionality rather than having to do your own object mapping.