### PR TITLE
Introduce a pipeline to the parameters

### DIFF
--- a/jest-common/src/main/java/io/searchbox/params/Parameters.java
+++ b/jest-common/src/main/java/io/searchbox/params/Parameters.java
@@ -87,6 +87,8 @@ public class Parameters {
 
     public static final String TRACK_SCORES = "track_scores";
 
+    public static final String PIPELINE = "pipeline";
+
     public static final List<String> ACCEPTED_IN_BULK = Arrays.asList(
             ROUTING,
             PERCOLATOR,
@@ -95,6 +97,7 @@ public class Parameters {
             TTL,
             RETRY_ON_CONFLICT,
             VERSION,
-            VERSION_TYPE
+            VERSION_TYPE,
+            PIPELINE
     );
 }

--- a/jest-common/src/test/java/io/searchbox/core/BulkTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/BulkTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.searchbox.params.Parameters;
 import io.searchbox.client.config.ElasticsearchVersion;
 import org.json.JSONException;
 import org.junit.Test;
@@ -104,11 +105,15 @@ public class BulkTest {
 
     @Test
     public void testUris() {
-        Bulk bulkWitIndex = new Bulk.Builder().defaultIndex("twitter").build();
-        assertEquals("twitter/_bulk", bulkWitIndex.getURI(ElasticsearchVersion.UNKNOWN));
+        Bulk bulkWithIndex = new Bulk.Builder().defaultIndex("twitter").build();
+        assertEquals("twitter/_bulk", bulkWithIndex.getURI(ElasticsearchVersion.UNKNOWN));
 
-        Bulk bulkWitIndexAndType = new Bulk.Builder().defaultIndex("twitter").defaultType("tweet").build();
-        assertEquals("twitter/tweet/_bulk", bulkWitIndexAndType.getURI(ElasticsearchVersion.UNKNOWN));
+        Bulk bulkWithIndexAndType = new Bulk.Builder().defaultIndex("twitter").defaultType("tweet").build();
+        assertEquals("twitter/tweet/_bulk", bulkWithIndexAndType.getURI(ElasticsearchVersion.UNKNOWN));
+
+        Bulk bulkWithPipeline = new Bulk.Builder().defaultIndex("twitter").defaultType("tweet")
+                .setParameter(Parameters.PIPELINE, "mo_base").build();
+        assertEquals("twitter/tweet/_bulk?pipeline=mo_base", bulkWithPipeline.getURI(ElasticsearchVersion.UNKNOWN));
     }
 
     @Test

--- a/jest-common/src/test/java/io/searchbox/core/IndexTest.java
+++ b/jest-common/src/test/java/io/searchbox/core/IndexTest.java
@@ -34,6 +34,18 @@ public class IndexTest {
     }
 
     @Test
+    public void indexDocumentWithPipelineParameter() {
+        Index index = new Index.Builder(new Object())
+                .index("twitter")
+                .type("tweet")
+                .id("1")
+                .setParameter(Parameters.PIPELINE, "mo_base")
+                .build();
+        assertEquals("PUT", index.getRestMethodName());
+        assertEquals("twitter/tweet/1?pipeline=mo_base", index.getURI(ElasticsearchVersion.UNKNOWN));
+    }
+
+    @Test
     public void indexDocumentWithoutId() {
         Index index = new Index.Builder(new Object()).index("twitter").type("tweet").build();
         assertEquals("POST", index.getRestMethodName());


### PR DESCRIPTION
This PR resurrects unmerged PR #513 , work by Alexander Zafirov @z4f1r0v .

I found I needed this change, and rebased to master, resolved conflicts and made the required API changes since the original work.

There may be ongoing, future issues with `ACCEPTED_IN_BULK`, being a static list with no way to bypass for Bulk support - it might be better to not filter these parameters at all and leave it the responsibility of the Bulk API user to ensure that incompatible query parameters are not set (they will yield an API error when they are).

Fixes #479 .