### PR TITLE
Update elastic analysis-common package

### DIFF
--- a/jest/pom.xml
+++ b/jest/pom.xml
@@ -154,7 +154,7 @@
             <artifactId>lang-mustache-client</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch.module</groupId>
+            <groupId>org.codelibs.elasticsearch.module</groupId>
             <artifactId>analysis-common</artifactId>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -14,6 +14,7 @@
     <modules>
         <module>jest-common</module>
         <module>jest</module>
+        <module>jest-droid</module>
     </modules>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,6 @@
     <modules>
         <module>jest-common</module>
         <module>jest</module>
-        <module>jest-droid</module>
     </modules>
 
     <licenses>
@@ -327,7 +326,7 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
-                <groupId>org.elasticsearch.module</groupId>
+                <groupId>org.codelibs.elasticsearch.module</groupId>
                 <artifactId>analysis-common</artifactId>
                 <version>${elasticsearch.version}</version>
                 <scope>test</scope>


### PR DESCRIPTION
org.elasticsearch.plugin:analysis-common is no longer available causing the build to fail