### PR TITLE
Updating Log4j version to 2.17.0 because of CVE-2021-45105 vulnerability.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
         <httpclientandroid.version>4.3.5.1</httpclientandroid.version>
 
         <slf4j.version>1.7.25</slf4j.version>
-        <log4j.version>2.7</log4j.version>
+        <log4j.version>2.17.0</log4j.version>
 
         <guava.version>21.0</guava.version>
         <gson.version>2.8.0</gson.version>


### PR DESCRIPTION
Update Log4j version to 2.17.0
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-45105
